### PR TITLE
Fix rates api call, backup should still be Bitpay

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/manager/BRApiManager.java
+++ b/app/src/main/java/com/breadwallet/tools/manager/BRApiManager.java
@@ -180,8 +180,7 @@ public class BRApiManager {
         JSONArray jsonArray = null;
         if (jsonString == null) return null;
         try {
-            JSONObject obj = new JSONObject(jsonString);
-            jsonArray = obj.getJSONArray("body");
+            jsonArray = new JSONArray(jsonString);
 
         } catch (JSONException ignored) {
         }


### PR DESCRIPTION
In case our precio server goes down we will still fetch Bitpay instead.