### PR TITLE
Segwit bech32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId = 'co.hodlwallet'
         minSdkVersion 23
         targetSdkVersion 27
-        versionCode 3
-        versionName "3.1"
+        versionCode 4
+        versionName "3.2.0"
         multiDexEnabled true
 
         // Similar to other properties in the defaultConfig block,

--- a/app/src/main/java/co/hodlwallet/presenter/activities/BreadActivity.java
+++ b/app/src/main/java/co/hodlwallet/presenter/activities/BreadActivity.java
@@ -169,6 +169,14 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
                 }
             }, 1000);
 
+        if (!BRSharedPrefs.getSegwitShown(BreadActivity.this))
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    BRAnimator.showSegwitMessage(BreadActivity.this);
+                    BRSharedPrefs.putSegwitShown(BreadActivity.this, true);
+                }
+            }, 1000);
 
         onConnectionChanged(InternetManager.getInstance().isConnected(this));
 

--- a/app/src/main/java/co/hodlwallet/presenter/activities/InputWordsActivity.java
+++ b/app/src/main/java/co/hodlwallet/presenter/activities/InputWordsActivity.java
@@ -222,6 +222,7 @@ public class InputWordsActivity extends BRActivity {
                         BRSharedPrefs.putAllowSpend(app, false);
                         //if this screen is shown then we did not upgrade to the new app, we installed it
                         BRSharedPrefs.putGreetingsShown(app, true);
+                        BRSharedPrefs.putSegwitShown(app, true);
                         PostAuth.getInstance().onRecoverWalletAuth(app, false);
                     }
 

--- a/app/src/main/java/co/hodlwallet/presenter/activities/SetPinActivity.java
+++ b/app/src/main/java/co/hodlwallet/presenter/activities/SetPinActivity.java
@@ -73,6 +73,7 @@ public class SetPinActivity extends BRActivity {
         });
         keyboard.setShowDot(false);
         BRSharedPrefs.putGreetingsShown(this, true);
+        BRSharedPrefs.putSegwitShown(this, true);
 
     }
 

--- a/app/src/main/java/co/hodlwallet/presenter/activities/settings/AboutActivity.java
+++ b/app/src/main/java/co/hodlwallet/presenter/activities/settings/AboutActivity.java
@@ -80,7 +80,7 @@ public class AboutActivity extends BRActivity {
         blogShare.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://hodlwallet.co"));
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://hodlwallet.com"));
                 startActivity(browserIntent);
                 app.overridePendingTransition(R.anim.enter_from_bottom, R.anim.empty_300);
             }
@@ -88,7 +88,7 @@ public class AboutActivity extends BRActivity {
         policyText.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://hodlwallet.co/privacy-policy"));
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://hodlwallet.com/privacy-policy"));
                 startActivity(browserIntent);
                 app.overridePendingTransition(R.anim.enter_from_bottom, R.anim.empty_300);
             }

--- a/app/src/main/java/co/hodlwallet/presenter/activities/settings/SettingsActivity.java
+++ b/app/src/main/java/co/hodlwallet/presenter/activities/settings/SettingsActivity.java
@@ -15,10 +15,12 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import co.hodlwallet.R;
+import co.hodlwallet.presenter.activities.BreadActivity;
 import co.hodlwallet.presenter.activities.util.ActivityUTILS;
 import co.hodlwallet.presenter.activities.util.BRActivity;
 import co.hodlwallet.presenter.entities.BRSettingsItem;
 import co.hodlwallet.presenter.interfaces.BRAuthCompletion;
+import co.hodlwallet.tools.animation.BRAnimator;
 import co.hodlwallet.tools.manager.BRSharedPrefs;
 import co.hodlwallet.tools.security.AuthManager;
 import com.platform.APIClient;
@@ -136,6 +138,13 @@ public class SettingsActivity extends BRActivity {
                 Intent intent = new Intent(SettingsActivity.this, WipeActivity.class);
                 startActivity(intent);
                 overridePendingTransition(R.anim.enter_from_bottom, R.anim.empty_300);
+            }
+        }, false));
+
+        items.add(new BRSettingsItem(getString(R.string.Settings_legacyAddress), "", new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                BRAnimator.showLegacyFragment(SettingsActivity.this, true);
             }
         }, false));
 

--- a/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentLegacyAddress.java
+++ b/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentLegacyAddress.java
@@ -1,0 +1,342 @@
+package co.hodlwallet.presenter.fragments;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.Button;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import co.hodlwallet.HodlApp;
+import co.hodlwallet.R;
+import co.hodlwallet.presenter.activities.settings.WebViewActivity;
+import co.hodlwallet.presenter.customviews.BRButton;
+import co.hodlwallet.presenter.customviews.BRKeyboard;
+import co.hodlwallet.presenter.customviews.BRLinearLayoutWithCaret;
+import co.hodlwallet.tools.animation.BRAnimator;
+import co.hodlwallet.tools.animation.SlideDetector;
+import co.hodlwallet.tools.manager.BRClipboardManager;
+import co.hodlwallet.tools.manager.BRSharedPrefs;
+import co.hodlwallet.tools.qrcode.QRUtils;
+import co.hodlwallet.tools.threads.BRExecutor;
+import co.hodlwallet.tools.util.BRConstants;
+import co.hodlwallet.tools.util.Utils;
+import co.hodlwallet.wallet.BRWalletManager;
+
+import static co.hodlwallet.tools.animation.BRAnimator.animateBackgroundDim;
+import static co.hodlwallet.tools.animation.BRAnimator.animateSignalSlide;
+import static com.platform.HTTPServer.URL_SUPPORT;
+
+/**
+ * BreadWallet
+ * <p>
+ * Created by Mihail Gutan <mihail@breadwallet.com> on 6/29/15.
+ * Copyright (c) 2016 breadwallet LLC
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+public class FragmentLegacyAddress extends Fragment {
+    private static final String TAG = FragmentLegacyAddress.class.getName();
+
+    public TextView mTitle;
+    public TextView mAddress;
+    public ImageView mQrImage;
+    public LinearLayout backgroundLayout;
+    public LinearLayout signalLayout;
+    private String legacyAddress;
+    private View separator;
+    private BRButton shareButton;
+    private Button shareEmail;
+    private Button shareTextMessage;
+    private Button requestButton;
+    private BRLinearLayoutWithCaret shareButtonsLayout;
+    private BRLinearLayoutWithCaret copiedLayout;
+    private boolean shareButtonsShown = false;
+    private boolean isLegacy;
+    private ImageButton close;
+    private Handler copyCloseHandler = new Handler();
+    private BRKeyboard keyboard;
+    private View separator2;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        // The last two arguments ensure LayoutParams are inflated
+        // properly.
+
+        View rootView = inflater.inflate(R.layout.fragment_receive, container, false);
+        mTitle = (TextView) rootView.findViewById(R.id.title);
+        mAddress = (TextView) rootView.findViewById(R.id.address_text);
+        mQrImage = (ImageView) rootView.findViewById(R.id.qr_image);
+        backgroundLayout = (LinearLayout) rootView.findViewById(R.id.background_layout);
+        signalLayout = (LinearLayout) rootView.findViewById(R.id.signal_layout);
+        shareButton = (BRButton) rootView.findViewById(R.id.share_button);
+        shareEmail = (Button) rootView.findViewById(R.id.share_email);
+        shareTextMessage = (Button) rootView.findViewById(R.id.share_text);
+        shareButtonsLayout = (BRLinearLayoutWithCaret) rootView.findViewById(R.id.share_buttons_layout);
+        copiedLayout = (BRLinearLayoutWithCaret) rootView.findViewById(R.id.copied_layout);
+        requestButton = (Button) rootView.findViewById(R.id.request_button);
+        keyboard = (BRKeyboard) rootView.findViewById(R.id.keyboard);
+        keyboard.setBRButtonBackgroundResId(R.drawable.keyboard_white_button);
+        keyboard.setBRKeyboardColor(R.color.white);
+        separator = rootView.findViewById(R.id.separator);
+        close = (ImageButton) rootView.findViewById(R.id.close_button);
+        separator2 = rootView.findViewById(R.id.separator2);
+        separator2.setVisibility(View.GONE);
+        setListeners();
+        BRWalletManager.getInstance().addBalanceChangedListener(new BRWalletManager.OnBalanceChanged() {
+            @Override
+            public void onBalanceChanged(long balance) {
+                updateQr();
+            }
+        });
+
+        ImageButton faq = (ImageButton) rootView.findViewById(R.id.faq_button);
+
+        faq.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                Activity app = getActivity();
+                if (app == null) {
+                    Log.e(TAG, "onClick: app is null, can't start the webview with url: " + URL_SUPPORT);
+                    return;
+                }
+
+                BRAnimator.showSupportFragment(app, BRConstants.receive);
+            }
+        });
+
+        signalLayout.removeView(shareButtonsLayout);
+        signalLayout.removeView(copiedLayout);
+
+        shareButtonsLayout.setBackgroundColor(getContext().getColor(R.color.dark_gray));
+        copiedLayout.setBackgroundColor(getContext().getColor(R.color.gray_background));
+
+        signalLayout.setLayoutTransition(BRAnimator.getDefaultTransition());
+
+        return rootView;
+    }
+
+
+    private void setListeners() {
+        shareEmail.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                String bitcoinUri = Utils.createBitcoinUrl(legacyAddress, 0, null, null, null);
+                QRUtils.share("mailto:", getActivity(), bitcoinUri);
+
+            }
+        });
+        shareTextMessage.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                String bitcoinUri = Utils.createBitcoinUrl(legacyAddress, 0, null, null, null);
+                QRUtils.share("sms:", getActivity(), bitcoinUri);
+            }
+        });
+        shareButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                shareButtonsShown = !shareButtonsShown;
+                showShareButtons(shareButtonsShown);
+            }
+        });
+        mAddress.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                copyText();
+            }
+        });
+        requestButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                Activity app = getActivity();
+                app.onBackPressed();
+                BRAnimator.showRequestFragment(app, legacyAddress);
+
+            }
+        });
+
+        backgroundLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                getActivity().onBackPressed();
+            }
+        });
+        mQrImage.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                copyText();
+            }
+        });
+
+        close.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Activity app = getActivity();
+                if (app != null)
+                    app.getFragmentManager().popBackStack();
+            }
+        });
+    }
+
+    private void showShareButtons(boolean b) {
+        if (!b) {
+            signalLayout.removeView(shareButtonsLayout);
+        } else {
+            signalLayout.addView(shareButtonsLayout, isLegacy ? signalLayout.getChildCount() - 2 : signalLayout.getChildCount());
+            showCopiedLayout(false);
+        }
+    }
+
+    private void showCopiedLayout(boolean b) {
+        if (!b) {
+            signalLayout.removeView(copiedLayout);
+            copyCloseHandler.removeCallbacksAndMessages(null);
+        } else {
+            if (signalLayout.indexOfChild(copiedLayout) == -1) {
+                signalLayout.addView(copiedLayout, signalLayout.indexOfChild(shareButton));
+                showShareButtons(false);
+                shareButtonsShown = false;
+                copyCloseHandler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        signalLayout.removeView(copiedLayout);
+                    }
+                }, 2000);
+            } else {
+                copyCloseHandler.removeCallbacksAndMessages(null);
+                signalLayout.removeView(copiedLayout);
+            }
+        }
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        final ViewTreeObserver observer = signalLayout.getViewTreeObserver();
+        observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                observer.removeGlobalOnLayoutListener(this);
+                animateBackgroundDim(backgroundLayout, false);
+                animateSignalSlide(signalLayout, false, null);
+            }
+        });
+
+        Bundle extras = getArguments();
+        isLegacy = extras.getBoolean("legacy");
+        if (!isLegacy) {
+            signalLayout.removeView(separator);
+            signalLayout.removeView(requestButton);
+            mTitle.setText(getString(R.string.UnlockScreen_myAddress));
+        }
+
+        BRExecutor.getInstance().forLightWeightBackgroundTasks().execute(new Runnable() {
+            @Override
+            public void run() {
+                updateQr();
+            }
+        });
+
+    }
+
+    private void updateQr() {
+        final Context ctx = getContext() == null ? HodlApp.getBreadContext() : (Activity) getContext();
+        BRExecutor.getInstance().forLightWeightBackgroundTasks().execute(new Runnable() {
+            @Override
+            public void run() {
+                boolean success = BRWalletManager.refreshAddress(ctx);
+                if (!success) {
+                    if (ctx instanceof Activity) {
+                        BRExecutor.getInstance().forMainThreadTasks().execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                ((Activity) ctx).onBackPressed();
+                            }
+                        });
+
+                    }
+                    return;
+                }
+                BRExecutor.getInstance().forMainThreadTasks().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        // TODO fix this, use legacy instead of normal address
+                        legacyAddress = BRSharedPrefs.getLegacyAddress(ctx);
+                        mAddress.setText(legacyAddress);
+                        boolean generated = QRUtils.generateQR(ctx, "bitcoin:" + legacyAddress, mQrImage);
+                        if (!generated)
+                            throw new RuntimeException("failed to generate qr image for address");
+                    }
+                });
+            }
+        });
+
+    }
+
+    private void copyText() {
+        BRClipboardManager.putClipboard(getContext(), mAddress.getText().toString());
+        showCopiedLayout(true);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        animateBackgroundDim(backgroundLayout, true);
+        animateSignalSlide(signalLayout, true, new BRAnimator.OnSlideAnimationEnd() {
+            @Override
+            public void onAnimationEnd() {
+                if (getActivity() != null)
+                    getActivity().getFragmentManager().popBackStack();
+            }
+        });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+    }
+
+}

--- a/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentLegacyAddress.java
+++ b/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentLegacyAddress.java
@@ -110,6 +110,9 @@ public class FragmentLegacyAddress extends Fragment {
         close = (ImageButton) rootView.findViewById(R.id.close_button);
         separator2 = rootView.findViewById(R.id.separator2);
         separator2.setVisibility(View.GONE);
+
+        mTitle.setText(R.string.Settings_legacyAddressTitle);
+
         setListeners();
         BRWalletManager.getInstance().addBalanceChangedListener(new BRWalletManager.OnBalanceChanged() {
             @Override

--- a/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentSegwit.java
+++ b/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentSegwit.java
@@ -1,0 +1,104 @@
+package co.hodlwallet.presenter.fragments;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.constraint.ConstraintLayout;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.RelativeLayout;
+
+import co.hodlwallet.presenter.customviews.BRButton;
+import co.hodlwallet.R;
+import co.hodlwallet.tools.animation.BRAnimator;
+
+/**
+ * BreadWallet
+ * <p>
+ * Created by Igor Guerrero <igor@bitstop.co> on 1/1/19.
+ * Copyright (c) 2019 HODL Wallet
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+public class FragmentSegwit extends Fragment {
+    private static final String TAG = FragmentSegwit.class.getName();
+
+    private BRButton ok;
+    private ConstraintLayout mainLayout;
+    private RelativeLayout background;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_segwit, container, false);
+        ok = (BRButton) rootView.findViewById(R.id.ok);
+        mainLayout = (ConstraintLayout) rootView.findViewById(R.id.signal_layout);
+        background = (RelativeLayout) rootView.findViewById(R.id.layout);
+
+        ok.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                getActivity().onBackPressed();
+            }
+        });
+
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        final ViewTreeObserver observer = mainLayout.getViewTreeObserver();
+        observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                observer.removeOnGlobalLayoutListener(this);
+                BRAnimator.animateBackgroundDim(background, false);
+                BRAnimator.animateSignalSlide(mainLayout, false, null);
+            }
+        });
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        BRAnimator.animateBackgroundDim(background, true);
+        BRAnimator.animateSignalSlide(mainLayout, true, new BRAnimator.OnSlideAnimationEnd() {
+            @Override
+            public void onAnimationEnd() {
+                if (getActivity() != null)
+                    getActivity().getFragmentManager().popBackStack();
+            }
+        });
+
+    }
+
+    @Override
+    public void onResume() { super.onResume(); }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+    }
+
+}

--- a/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentSegwit.java
+++ b/app/src/main/java/co/hodlwallet/presenter/fragments/FragmentSegwit.java
@@ -4,6 +4,7 @@ import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.constraint.ConstraintLayout;
+import android.text.method.ScrollingMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,6 +13,7 @@ import android.widget.RelativeLayout;
 
 import co.hodlwallet.presenter.customviews.BRButton;
 import co.hodlwallet.R;
+import co.hodlwallet.presenter.customviews.BRText;
 import co.hodlwallet.tools.animation.BRAnimator;
 
 /**
@@ -43,6 +45,7 @@ public class FragmentSegwit extends Fragment {
     private static final String TAG = FragmentSegwit.class.getName();
 
     private BRButton ok;
+    private BRText message;
     private ConstraintLayout mainLayout;
     private RelativeLayout background;
 
@@ -51,6 +54,7 @@ public class FragmentSegwit extends Fragment {
                              ViewGroup container, Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_segwit, container, false);
         ok = (BRButton) rootView.findViewById(R.id.ok);
+        message = (BRText) rootView.findViewById(R.id.BRText4);
         mainLayout = (ConstraintLayout) rootView.findViewById(R.id.signal_layout);
         background = (RelativeLayout) rootView.findViewById(R.id.layout);
 
@@ -60,6 +64,7 @@ public class FragmentSegwit extends Fragment {
                 getActivity().onBackPressed();
             }
         });
+        message.setMovementMethod(new ScrollingMovementMethod());
 
         return rootView;
     }

--- a/app/src/main/java/co/hodlwallet/tools/animation/BRAnimator.java
+++ b/app/src/main/java/co/hodlwallet/tools/animation/BRAnimator.java
@@ -30,6 +30,7 @@ import co.hodlwallet.presenter.activities.camera.ScanQRActivity;
 import co.hodlwallet.presenter.customviews.BRDialogView;
 import co.hodlwallet.presenter.entities.TxItem;
 import co.hodlwallet.presenter.fragments.FragmentGreetings;
+import co.hodlwallet.presenter.fragments.FragmentLegacyAddress;
 import co.hodlwallet.presenter.fragments.FragmentMenu;
 import co.hodlwallet.presenter.fragments.FragmentSignal;
 import co.hodlwallet.presenter.fragments.FragmentReceive;
@@ -330,6 +331,27 @@ public class BRAnimator {
                 .setCustomAnimations(0, 0, 0, R.animator.plain_300)
                 .add(android.R.id.content, fragmentReceive, FragmentReceive.class.getName())
                 .addToBackStack(FragmentReceive.class.getName()).commit();
+
+    }
+
+    //isReceive tells the Animator that the Receive fragment is requested, not My Address
+    public static void showLegacyFragment(Activity app, boolean isLegacy) {
+        if (app == null) {
+            Log.e(TAG, "showLegacyFragment: app is null");
+            return;
+        }
+        FragmentLegacyAddress fragmentLegacyAddress = (FragmentLegacyAddress) app.getFragmentManager().findFragmentByTag(FragmentLegacyAddress.class.getName());
+        if (fragmentLegacyAddress != null && fragmentLegacyAddress.isAdded())
+            return;
+        fragmentLegacyAddress = new FragmentLegacyAddress();
+        Bundle args = new Bundle();
+        args.putBoolean("legacy", isLegacy);
+        fragmentLegacyAddress.setArguments(args);
+
+        app.getFragmentManager().beginTransaction()
+                .setCustomAnimations(0, 0, 0, R.animator.plain_300)
+                .add(android.R.id.content, fragmentLegacyAddress, FragmentLegacyAddress.class.getName())
+                .addToBackStack(FragmentLegacyAddress.class.getName()).commit();
 
     }
 

--- a/app/src/main/java/co/hodlwallet/tools/animation/BRAnimator.java
+++ b/app/src/main/java/co/hodlwallet/tools/animation/BRAnimator.java
@@ -31,6 +31,7 @@ import co.hodlwallet.presenter.customviews.BRDialogView;
 import co.hodlwallet.presenter.entities.TxItem;
 import co.hodlwallet.presenter.fragments.FragmentGreetings;
 import co.hodlwallet.presenter.fragments.FragmentLegacyAddress;
+import co.hodlwallet.presenter.fragments.FragmentSegwit;
 import co.hodlwallet.presenter.fragments.FragmentMenu;
 import co.hodlwallet.presenter.fragments.FragmentSignal;
 import co.hodlwallet.presenter.fragments.FragmentReceive;
@@ -379,6 +380,19 @@ public class BRAnimator {
         transaction.addToBackStack(FragmentGreetings.class.getName());
         transaction.commit();
 
+    }
+
+    public static void showSegwitMessage(Activity app) {
+        if (app == null) {
+            Log.e(TAG, "showSegwitMessage: app is null");
+            return;
+        }
+
+        FragmentTransaction transaction = app.getFragmentManager().beginTransaction();
+        transaction.setCustomAnimations(0, 0, 0, R.animator.plain_300);
+        transaction.add(android.R.id.content, new FragmentSegwit(), FragmentSegwit.class.getName());
+        transaction.addToBackStack(FragmentSegwit.class.getName());
+        transaction.commit();
     }
 
     public static boolean isClickAllowed() {

--- a/app/src/main/java/co/hodlwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/co/hodlwallet/tools/manager/BRSharedPrefs.java
@@ -142,6 +142,17 @@ public class BRSharedPrefs {
         editor.apply();
     }
 
+    public static String getLegacyAddress(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(BRConstants.LEGACY_ADDRESS, "");
+    }
+
+    public static void putLegacyAddress(Context ctx, String tmpAddr) {
+        SharedPreferences.Editor editor = ctx.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE).edit();
+        editor.putString(BRConstants.LEGACY_ADDRESS, tmpAddr);
+        editor.apply();
+    }
+
     public static String getWalletName(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getString(BRConstants.WALLET_NAME, "My Bread");

--- a/app/src/main/java/co/hodlwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/co/hodlwallet/tools/manager/BRSharedPrefs.java
@@ -112,10 +112,22 @@ public class BRSharedPrefs {
 
     }
 
+    public static boolean getSegwitShown(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getBoolean("segwitShown", false);
+    }
+
     public static void putGreetingsShown(Context context, boolean shown) {
         SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("greetingsShown", shown);
+        editor.apply();
+    }
+
+    public static void putSegwitShown(Context context, boolean shown) {
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean("segwitShown", shown);
         editor.apply();
     }
 

--- a/app/src/main/java/co/hodlwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/co/hodlwallet/tools/util/BRConstants.java
@@ -97,6 +97,7 @@ public class BRConstants {
      */
     public static final String PREFS_NAME = "MyPrefsFile";
     public static final String RECEIVE_ADDRESS = "receive_address";
+    public static final String LEGACY_ADDRESS = "legacy_address";
     public static final String WALLET_NAME = "wallet_name";
     public static final String START_HEIGHT = "startHeight";
     public static final String LAST_BLOCK_HEIGHT = "lastBlockHeight";

--- a/app/src/main/java/co/hodlwallet/wallet/BRWalletManager.java
+++ b/app/src/main/java/co/hodlwallet/wallet/BRWalletManager.java
@@ -259,11 +259,18 @@ public class BRWalletManager {
 
     public static boolean refreshAddress(Context ctx) {
         String address = getReceiveAddress();
-        if (Utils.isNullOrEmpty(address)) {
+        String legacyAddress = getLegacyAddress();
+
+        if (Utils.isNullOrEmpty(address) || Utils.isNullOrEmpty(legacyAddress)) {
             Log.e(TAG, "refreshAddress: WARNING, retrieved address:" + address);
+            Log.e(TAG, "refreshAddress: WARNING, retrieved legacy address address:" + legacyAddress);
+
             return false;
         }
+
         BRSharedPrefs.putReceiveAddress(ctx, address);
+        BRSharedPrefs.putLegacyAddress(ctx, legacyAddress);
+
         return true;
 
     }
@@ -612,6 +619,8 @@ public class BRWalletManager {
     public native byte[] getMasterPubKey(byte[] normalizedString);
 
     public static native String getReceiveAddress();
+
+    public static native String getLegacyAddress();
 
     public native TxItem[] getTransactions();
 

--- a/app/src/main/java/co/platform/HTTPServer.java
+++ b/app/src/main/java/co/platform/HTTPServer.java
@@ -69,7 +69,7 @@ public class HTTPServer {
     public static final int PORT = 31120;
     public static final String URL_EA = "http://localhost:" + PORT + "/ea";
     public static final String URL_BUY = "http://localhost:" + PORT + "/buy";
-    public static final String URL_SUPPORT = "https://hodlwallet.co";
+    public static final String URL_SUPPORT = "https://hodlwallet.com";
     public static ServerMode mode;
 
     public enum ServerMode {

--- a/app/src/main/jni/transition/wallet.c
+++ b/app/src/main/jni/transition/wallet.c
@@ -800,7 +800,7 @@ Java_co_hodlwallet_wallet_BRWalletManager_addInputToPrivKeyTx(JNIEnv *env, jobje
 
     BRTransactionAddInput(_privKeyTx, reversedHash, (uint32_t) vout, (uint64_t) amount,
                           (const uint8_t *) rawScript,
-                          (size_t) scriptLength, NULL, 0, TXIN_SEQUENCE);
+                          (size_t) scriptLength, NULL, 0, NULL, 0, TXIN_SEQUENCE);
 }
 
 JNIEXPORT jobject JNICALL Java_co_hodlwallet_wallet_BRWalletManager_getPrivKeyObject(JNIEnv *env,

--- a/app/src/main/jni/transition/wallet.c
+++ b/app/src/main/jni/transition/wallet.c
@@ -345,6 +345,17 @@ JNIEXPORT jstring JNICALL Java_co_hodlwallet_wallet_BRWalletManager_getReceiveAd
     return (*env)->NewStringUTF(env, receiveAddress.s);
 }
 
+JNIEXPORT jstring JNICALL Java_co_hodlwallet_wallet_BRWalletManager_getLegacyAddress(JNIEnv *env,
+                                                                                      jobject thiz) {
+    __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "getLegacyAddress");
+    if (!_wallet) return NULL;
+
+    BRAddress legacyAddress = BRWalletLegacyAddress(_wallet);
+    __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "legacyAddress: %s",
+                        legacyAddress.s);
+    return (*env)->NewStringUTF(env, legacyAddress.s);
+}
+
 JNIEXPORT jobjectArray JNICALL Java_co_hodlwallet_wallet_BRWalletManager_getTransactions(
     JNIEnv *env, jobject thiz) {
     __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "getTransactions");

--- a/app/src/main/res/layout/fragment_segwit.xml
+++ b/app/src/main/res/layout/fragment_segwit.xml
@@ -1,0 +1,92 @@
+<co.hodlwallet.presenter.customviews.BRRelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent"
+    android:filterTouchesWhenObscured="true"
+    android:orientation="vertical"
+    android:padding="0dp">
+
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/signal_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_gravity="center"
+        android:layout_margin="16dp"
+        android:background="@drawable/bread_dialog_rounded"
+        android:clickable="true"
+        android:orientation="vertical"
+        android:padding="0dp">
+
+        <LinearLayout
+            android:id="@+id/linearLayout4"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
+            android:layout_marginTop="0dp"
+            android:background="@drawable/rounded_gradient_header"
+            android:orientation="horizontal"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+        </LinearLayout>
+
+        <co.hodlwallet.presenter.customviews.BRText
+            android:id="@+id/BRText3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="24dp"
+            android:text="@string/Segwit.title"
+            android:textColor="@color/white"
+            android:textSize="28sp"
+            app:layout_constraintHorizontal_bias="0.511"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/linearLayout4"/>
+
+        <co.hodlwallet.presenter.customviews.BRText
+            android:id="@+id/BRText4"
+            android:layout_width="316dp"
+            android:layout_height="186dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="17dp"
+            android:layout_marginRight="16dp"
+            android:lineSpacingMultiplier="1.3"
+            android:text="@string/Segwit.message"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/BRText3" />
+
+        <co.hodlwallet.presenter.customviews.BRButton
+            android:id="@+id/ok"
+            android:layout_width="0dp"
+            android:layout_height="80dp"
+            android:layout_marginTop="20dp"
+            android:background="@color/dark_gray"
+            app:isBreadButton="false"
+            app:buttonType="1"
+            android:text="@string/Button.ok"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/BRText4"
+            app:layout_constraintVertical_bias="1.0"/>
+
+    </android.support.constraint.ConstraintLayout>
+
+</co.hodlwallet.presenter.customviews.BRRelativeLayout>

--- a/app/src/main/res/layout/fragment_segwit.xml
+++ b/app/src/main/res/layout/fragment_segwit.xml
@@ -40,34 +40,37 @@
             android:id="@+id/BRText3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
             android:layout_marginLeft="16dp"
             android:layout_marginRight="16dp"
-            android:layout_marginStart="16dp"
             android:layout_marginTop="24dp"
             android:text="@string/Segwit.title"
             android:textColor="@color/white"
-            android:textSize="28sp"
+            android:textSize="24sp"
             app:layout_constraintHorizontal_bias="0.511"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/linearLayout4"/>
+            app:layout_constraintTop_toBottomOf="@+id/linearLayout4" />
 
         <co.hodlwallet.presenter.customviews.BRText
             android:id="@+id/BRText4"
-            android:layout_width="316dp"
-            android:layout_height="186dp"
+            android:layout_width="0dp"
+            android:layout_height="340dp"
             android:layout_marginLeft="16dp"
-            android:layout_marginTop="17dp"
             android:layout_marginRight="16dp"
+            android:layout_marginTop="17dp"
+            android:fadeScrollbars="true"
+            android:isScrollContainer="true"
             android:lineSpacingMultiplier="1.3"
+            android:nestedScrollingEnabled="true"
+            android:scrollbars="vertical"
             android:text="@string/Segwit.message"
             android:textColor="@color/white"
             android:textSize="16sp"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/BRText3" />
+            app:layout_constraintTop_toBottomOf="@+id/BRText3"
+            tools:nestedScrollingEnabled="true" />
 
         <co.hodlwallet.presenter.customviews.BRButton
             android:id="@+id/ok"

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blog</string>
   <!-- About screen footer -->
-  <string name="About.footer">Lavet af det globale Bread hold. Version %1$s</string>
+  <string name="About.footer">Lavet af det globale HODL hold. Version %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Privatlivspolitik</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Indlæser pung</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Mit Bread</string>
+  <string name="AccountHeader.defaultWalletName">Mit HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Fejl</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Der er et problem med din Android OS keystore, kontakt venligst support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Der er et problem med din Android OS keystore, kontakt venligst support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Dine Bread-krypterede data blev for nyligt ugyldiggjort, eftersom din Android skærmlås blev deaktiveret.</string>
+  <string name="Alert.keystore.invalidated.android">Dine HODL-krypterede data blev for nyligt ugyldiggjort, eftersom din Android skærmlås blev deaktiveret.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Android KeyStore fejl</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Pung bliver importeret</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">Import af en pung overfører alle pengene fra din anden pung til din Bread pung, via en enkelt overførsel.</string>
+  <string name="Import.message">Import af en pung overfører alle pengene fra din anden pung til din HODL pung, via en enkelt overførsel.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Denne private nøgle er beskyttet med et kodeord.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">adgangskode</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Din Bread pung</string>
+  <string name="Import.rightCaption">Din HODL pung</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Scan privat nøgle</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Ignorer</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">ENHEDENS SIKKERHED ER KOMPROMITTERET\n Enhver \'jailbreak\' app kan få adgang til Breads nøgledata og stjæle dine bitcoin! Ryd straks denne pung og gendan på en sikker enhed.</string>
+  <string name="JailbreakWarnings.messageWithBalance">ENHEDENS SIKKERHED ER KOMPROMITTERET\n Enhver \'jailbreak\' app kan få adgang til HODLs nøgledata og stjæle dine bitcoin! Ryd straks denne pung og gendan på en sikker enhed.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">ENHEDENS SIKKERHED ER KOMPROMITTERET\n Enhver \'jailbreak\' app kan få adgang til Breads nøgledata og stjæle dine bitcoin. Brug kun Bread på en ikke jailbreaket enhed.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">ENHEDENS SIKKERHED ER KOMPROMITTERET\n Enhver \'jailbreak\' app kan få adgang til HODLs nøgledata og stjæle dine bitcoin. Brug kun HODL på en ikke jailbreaket enhed.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">ADVARSEL</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Placeringstjenester er deaktiveret.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread har ikke adgang til placeringstjenester.</string>
+  <string name="LocationPlugin.notAuthorized">HODL har ikke adgang til placeringstjenester.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Du lavede din pung den %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transaktion afvist</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Hjælp med at forbedre Bread ved at dele dine anonyme data med os</string>
+  <string name="Prompts.ShareData.body">Hjælp med at forbedre HODL ved at dele dine anonyme data med os</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Del anonyme data</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread er blevet opgraderet til at bruge en 6-cifret PIN. Tryk her for at opgradere.</string>
+  <string name="Prompts.UpgradePin.body">HODL er blevet opgraderet til at bruge en 6-cifret PIN. Tryk her for at opgradere.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Opgader PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Slå notifikationer til for at modtage særlige meddelelser fra Bread i fremtiden.</string>
+  <string name="PushNotifications.body">Slå notifikationer til for at modtage særlige meddelelser fra HODL i fremtiden.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Push notifikationer</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Indtast paper key</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Gendan dit Bread med din paper key.</string>
+  <string name="RecoverWallet.intro">Gendan dit HODL med din paper key.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">Den paper key du indtastede er ugyldig. Dobbelttjek hvert ord og prøv igen.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minutter</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Hvis en transaktion vises som gennemført i bitcoin netværket, men ikke i dit Bread.</string>
+  <string name="ReScan.body2">Hvis en transaktion vises som gennemført i bitcoin netværket, men ikke i dit HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Du modtager gentagne gange en fejlmeddelelse om at din transaktion er blevet afvist.</string>
   <!-- Start Sync button label -->
@@ -409,7 +409,7 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Paper key</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Beskytter dit Bread mod uberettigede brugere.</string>
+  <string name="SecurityCenter.pinDescription">Beskytter dit HODL mod uberettigede brugere.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6-cifret PIN</string>
   <!-- Security Center Title -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Balance: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Tillad adgang under \"Indstillinger\" &gt; \"Apps\" &gt; \"Bread\" &gt; \"Tilladelser\"</string>
+  <string name="Send.cameraUnavailabeMessage.android">Tillad adgang under \"Indstillinger\" &gt; \"Apps\" &gt; \"HODL\" &gt; \"Tilladelser\"</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread har ikke tilladelse til at få adgang til kameraet</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL har ikke tilladelse til at få adgang til kameraet</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Gå til Indstillinger og giv adgang til kamera.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread har ikke adgang til kameraet</string>
+  <string name="Send.cameraUnavailableTitle">HODL har ikke adgang til kameraet</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">Destinationen er din egen adresse. Du kan ikke sende til dig selv.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Vis valuta</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Tilmeld dig Early Access</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Nyder du Bread?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Nyder du HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importer pung</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">Legacy Adresse</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Hjælp med at forbedre Bread ved at dele dine anonyme data med os. Dette inkluderer ikke finansielle oplysninger. Vi respekterer dit finansielle privatliv.</string>
+  <string name="ShareData.body">Hjælp med at forbedre HODL ved at dele dine anonyme data med os. Dette inkluderer ikke finansielle oplysninger. Vi respekterer dit finansielle privatliv.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Del data?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Skriv paper key ned igen</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Din paper key er den eneste måde at gendanne dit Bread på, hvis din telefon mistes, stjæles, går i stykker eller opgraderes.\n\nVi viser dig en liste over word du skal skrive ned på et papir, og holde sikkert.</string>
+  <string name="StartPaperPhrase.body">Din paper key er den eneste måde at gendanne dit HODL på, hvis din telefon mistes, stjæles, går i stykker eller opgraderes.\n\nVi viser dig en liste over word du skal skrive ned på et papir, og holde sikkert.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Skriv paper key ned</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Autentificering via fingeraftryk ikke aktiveret</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Brug dit fingeraftryk til at låse op for dit Bread og sende penge op til en vis grænse.</string>
+  <string name="TouchIdSettings.label">Brug dit fingeraftryk til at låse op for dit HODL og sende penge op til en vis grænse.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Touch ID forbrugsgrænseside</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Brugsgrænse: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Aktiver Touch ID til Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Aktiver Touch ID til HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Aktiver autentificering via fingeraftryk</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Touch sensor</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Lås op for dit Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Lås op for dit HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Lås op for din Android enhed for at fortsætte</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Husk denne PIN. Hvis du glemmer den, vil du ikke kunne få adgang til dine bitcoin.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Din PIN bliver brugt til at låse op for dit Bread og sende penge.</string>
+  <string name="UpdatePin.createInstruction">Din PIN bliver brugt til at låse op for dit HODL og sende penge.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Indstil PIN</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Godkend denne transaktion</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Åben Bread iPhone appen for at konfigurere din pung.</string>
+  <string name="Watch.noWalletWarning">Åben HODL iPhone appen for at konfigurere din pung.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Afvis</string>
   <!-- Webview loading error message -->
@@ -711,11 +711,11 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Opdaterer...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet har skiftet navn til Bread med et helt nyt look og nogle nye funktioner.\n\nHvis du har brug for hjælp, led efter (?) øverst til højre på de fleste skærme.</string>
+  <string name="Welcome.body">HODLwallet har skiftet navn til HODL med et helt nyt look og nogle nye funktioner.\n\nHvis du har brug for hjælp, led efter (?) øverst til højre på de fleste skærme.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Velkommen til Bread!</string>
+  <string name="Welcome.title">Velkommen til HODL!</string>
   <!-- Top title of segwit popup -->
-  <string name="Segwit.title"></string>
+  <string name="Segwit.title">HODL Wallet har opgraderet!</string>
   <!-- Message of segwit popup -->
   <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Indtast denne wallets gendannelsessætning for at slette den og starte eller gendanne en anden. Din nuværende saldo forbliver med denne sætning.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Påbegyndelse eller gendannelse af en anden tegnebog giver mulighed for at få adgang samt administrere en Bread tegnebog på denne enhed.</string>
+  <string name="WipeWallet.startMessage">Påbegyndelse eller gendannelse af en anden tegnebog giver mulighed for at få adgang samt administrere en HODL tegnebog på denne enhed.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Du vil ikke længere være i stand til at få adgang til din nuværende Bread tegnebog fra denne enhed. Saldoen vil forblive på frasen.</string>
+  <string name="WipeWallet.startWarning">Du vil ikke længere være i stand til at få adgang til din nuværende HODL tegnebog fra denne enhed. Saldoen vil forblive på frasen.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Start eller gendan en anden wallet.</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Wallet</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Start/gendan en anden wallet</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Vis Legacy adresse</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Hjælp med at forbedre Bread ved at dele dine anonyme data med os. Dette inkluderer ikke finansielle oplysninger. Vi respekterer dit finansielle privatliv.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -511,7 +511,9 @@
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Start/gendan en anden wallet</string>
   <!-- Show Legacy Address. -->
-  <string name="Settings.legacyAddress">Vis Legacy adresse</string>
+  <string name="Settings.legacyAddress">Vis Legacy Adresse</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Legacy Adresse</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Hjælp med at forbedre Bread ved at dele dine anonyme data med os. Dette inkluderer ikke finansielle oplysninger. Vi respekterer dit finansielle privatliv.</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwallet har skiftet navn til Bread med et helt nyt look og nogle nye funktioner.\n\nHvis du har brug for hjælp, led efter (?) øverst til højre på de fleste skærme.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Velkommen til Bread!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Er du sikker på at du vil slette denne wallet?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -512,6 +512,8 @@
     <string name="Settings.wipe">Ein anderes Wallet starten/wiederherstellen</string>
     <!-- Show Legacy Address. -->
     <string name="Settings.legacyAddress">Legacy-Adresse anzeigen</string>
+    <!-- Get a legacy address menu label. -->
+    <string name="Settings.legacyAddressTitle">Legacy-Adresse</string>
     <!-- Share data view body -->
     <string name="ShareData.body">Hilf dabei, Bread zu verbessern, indem du uns deine Nutzungsdaten anonym übermittelst. Hiervon sind sämtliche Finanzinformationen ausgeschlossen. Wir respektieren deine finanzielle Privatsphäre.</string>
     <!-- Share data header -->
@@ -712,6 +714,10 @@
     <string name="Welcome.body">Breadwallet heißt jetzt Bread und hat ein brandneues Erscheinungsbild sowie einige neue Funktionen.\n\nWenn Sie Hilfe benötigen, halten Sie Ausschau nach dem (?), das auf den meisten Bildschirm oben rechts zu finden ist.</string>
     <!-- Top title of welcome screen -->
     <string name="Welcome.title">Willkommen bei Bread!</string>
+    <!-- Top title of segwit popup -->
+    <string name="Segwit.title"></string>
+    <!-- Message of segwit popup -->
+    <string name="Segwit.message"></string>
     <!-- Wipe wallet alert message -->
     <string name="WipeWallet.alertMessage">Sind Sie sicher, dass Sie dieses Wallet löschen möchten?</string>
     <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,7 +5,7 @@
     <!-- About screen blog label -->
     <string name="About.blog">Blog</string>
     <!-- About screen footer -->
-    <string name="About.footer">Erstellt vom globalen Bread-Team. Version %1$s</string>
+    <string name="About.footer">Erstellt vom globalen HODL-Team. Version %1$s</string>
     <!-- Privay Policy button label -->
     <string name="About.privacy">Datenschutzerklärung</string>
     <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
     <!-- Loading Wallet Message -->
     <string name="Account.loadingMessage">Wallet wird geladen</string>
     <!-- Default wallet name -->
-    <string name="AccountHeader.defaultWalletName">Mein Bread</string>
+    <string name="AccountHeader.defaultWalletName">Mein HODL</string>
     <!-- Equals symbol -->
     <string name="AccountHeader.equals">=</string>
     <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
     <!-- Error alert title -->
     <string name="Alert.error">Fehler</string>
     <!-- Keystore error -->
-    <string name="Alert.keystore.generic.android">Es liegt ein Problem mit dem KeyStore Ihres Android-Betriebssystems vor, bitte wenden Sie sich an support@breadwallet.com</string>
+    <string name="Alert.keystore.generic.android">Es liegt ein Problem mit dem KeyStore Ihres Android-Betriebssystems vor, bitte wenden Sie sich an support@hodlwallet.co</string>
     <!-- KeyStore error, keys are invalidated -->
-    <string name="Alert.keystore.invalidated.android">Ihre mit Bread verschlüsselten Daten wurden vor Kurzem für ungültig erklärt, da Ihre Android-Bildschirmsperre deaktiviert war.</string>
+    <string name="Alert.keystore.invalidated.android">Ihre mit HODL verschlüsselten Daten wurden vor Kurzem für ungültig erklärt, da Ihre Android-Bildschirmsperre deaktiviert war.</string>
     <!-- Keystore error title -->
     <string name="Alert.keystore.title.android">Android-KeyStore-Fehler</string>
     <!-- No internet alert message -->
@@ -189,13 +189,13 @@
     <!-- Caption for graphics -->
     <string name="Import.leftCaption">Zu importierendes Wallet</string>
     <!-- Import wallet intro screen message -->
-    <string name="Import.message">Der Import eines Wallets überträgt das gesamte Guthaben deines anderen Wallets mit einer einzigen Transaktion in dein Bread-Wallet.</string>
+    <string name="Import.message">Der Import eines Wallets überträgt das gesamte Guthaben deines anderen Wallets mit einer einzigen Transaktion in dein HODL-Wallet.</string>
     <!-- Enter password alert view title -->
     <string name="Import.password">Dieser private Schlüssel ist passwortgeschützt.</string>
     <!-- password textfield placeholder -->
     <string name="Import.passwordPlaceholder">Passwort</string>
     <!-- Caption for graphics -->
-    <string name="Import.rightCaption">Dein Bread-Wallet</string>
+    <string name="Import.rightCaption">Dein HODL-Wallet</string>
     <!-- Scan Private key button label -->
     <string name="Import.scan">Privaten Schlüssel scannen</string>
     <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
     <!-- Ignore jailbreak warning button -->
     <string name="JailbreakWarnings.ignore">Ignorieren</string>
     <!-- Jailbreak warning message -->
-    <string name="JailbreakWarnings.messageWithBalance">DAS GERÄT IST NICHT LÄNGER SICHER\nJede beliebige „Jailbreak“-App kann auf Breads Keychain-Daten zugreifen und deine Bitcoins stehlen! Lösche dieses Wallet unverzüglich und stelle es auf einem sicheren Gerät wieder her.</string>
+    <string name="JailbreakWarnings.messageWithBalance">DAS GERÄT IST NICHT LÄNGER SICHER\nJede beliebige „Jailbreak“-App kann auf HODLs Keychain-Daten zugreifen und deine Bitcoins stehlen! Lösche dieses Wallet unverzüglich und stelle es auf einem sicheren Gerät wieder her.</string>
     <!-- Jailbreak warning message -->
-    <string name="JailbreakWarnings.messageWithoutBalance">DAS GERÄT IST NICHT LÄNGER SICHER\nJede beliebige „Jailbreak“-App kann auf Breads Keychain-Daten zugreifen und deine Bitcoins stehlen. Bitte setze Bread ausschließlich auf Geräten ohne Jailbreak ein.</string>
+    <string name="JailbreakWarnings.messageWithoutBalance">DAS GERÄT IST NICHT LÄNGER SICHER\nJede beliebige „Jailbreak“-App kann auf HODLs Keychain-Daten zugreifen und deine Bitcoins stehlen. Bitte setze HODL ausschließlich auf Geräten ohne Jailbreak ein.</string>
     <!-- Jailbreak warning title -->
     <string name="JailbreakWarnings.title">ACHTUNG</string>
     <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
     <!-- Location services disabled error -->
     <string name="LocationPlugin.disabled">Standortdienste sind deaktiviert</string>
     <!-- No permissions for location services -->
-    <string name="LocationPlugin.notAuthorized">Bread fehlt die Berechtigung, um auf die Standortdienste zuzugreifen.</string>
+    <string name="LocationPlugin.notAuthorized">HODL fehlt die Berechtigung, um auf die Standortdienste zuzugreifen.</string>
     <!-- Wallet creation date prefix -->
     <string name="ManageWallet.creationDatePrefix">Du hast dein Wallet am %1$s erstellt</string>
     <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
     <!-- Transaction rejected prompt title -->
     <string name="Prompts.RecommendRescan.title">Transaktion abgelehnt</string>
     <!-- Share data prompt body -->
-    <string name="Prompts.ShareData.body">Tragen Sie zur Verbesserung von Bread bei, indem Sie Ihre anonymen Daten mit uns teilen</string>
+    <string name="Prompts.ShareData.body">Tragen Sie zur Verbesserung von HODL bei, indem Sie Ihre anonymen Daten mit uns teilen</string>
     <!-- Share data prompt title -->
     <string name="Prompts.ShareData.title">Anonyme Daten teilen</string>
     <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
     <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
     <string name="Prompts.TouchId.usePin.android">PIN</string>
     <!-- Upgrade PIN prompt body. -->
-    <string name="Prompts.UpgradePin.body">Bread nutzt mittlerweile eine 6-stellige PIN. Hier antippen, um upzugraden.</string>
+    <string name="Prompts.UpgradePin.body">HODL nutzt mittlerweile eine 6-stellige PIN. Hier antippen, um upzugraden.</string>
     <!-- Upgrade PIN prompt title. -->
     <string name="Prompts.UpgradePin.title">PIN upgraden</string>
     <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-    <string name="PushNotifications.body">Schalten Sie Benachrichtigungen ein, um in Zukunft besondere Meldungen von Bread zu erhalten.</string>
+    <string name="PushNotifications.body">Schalten Sie Benachrichtigungen ein, um in Zukunft besondere Meldungen von HODL zu erhalten.</string>
     <!-- Push notifications toggle switch label -->
     <string name="PushNotifications.label">Push-Benachrichtigungen</string>
     <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
     <!-- Enter paper key instruction -->
     <string name="RecoverWallet.instruction">Offlineschlüssel eingeben</string>
     <!-- Recover wallet intro -->
-    <string name="RecoverWallet.intro">Stelle dein Bread mithilfe deines Offlineschlüssels wieder her.</string>
+    <string name="RecoverWallet.intro">Stelle dein HODL mithilfe deines Offlineschlüssels wieder her.</string>
     <!-- Invalid paper key message -->
     <string name="RecoverWallet.invalid">Der von dir eingegebene Offlineschlüssel ist ungültig. Bitte überprüfe nochmal jedes Wort und versuche es erneut.</string>
     <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
     <!-- extimated time -->
     <string name="ReScan.body1">20–45 Minuten</string>
     <!-- Syncing explanation -->
-    <string name="ReScan.body2">Wenn eine Transaktion im Bitcoin-Netzwerk, aber nicht in deinem Bread als abgeschlossen angezeigt wird.</string>
+    <string name="ReScan.body2">Wenn eine Transaktion im Bitcoin-Netzwerk, aber nicht in deinem HODL als abgeschlossen angezeigt wird.</string>
     <!-- Syncing explanation -->
     <string name="ReScan.body3">Sie erhalten wiederholt eine Fehlermeldung, dass Ihre Transaktion abgewiesen wurde.</string>
     <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
     <!-- Paper Key button title -->
     <string name="SecurityCenter.paperKeyTitle">Offlineschlüssel</string>
     <!-- PIN button description -->
-    <string name="SecurityCenter.pinDescription">Schütze dein Bread vor nicht autorisierten Benutzern.</string>
+    <string name="SecurityCenter.pinDescription">Schütze dein HODL vor nicht autorisierten Benutzern.</string>
     <!-- PIN button title -->
     <string name="SecurityCenter.pinTitle">6-stellige PIN</string>
     <!-- Security Center Title -->
     <string name="SecurityCenter.title">Sicherheits-Center</string>
     <!-- Touch ID button description -->
-    <string name="SecurityCenter.touchIdDescription">Eine praktische Möglichkeit, dein Bread zu entsperren und Geld bis zu einer festlegbaren Höchstgrenze zu versenden.</string>
+    <string name="SecurityCenter.touchIdDescription">Eine praktische Möglichkeit, dein HODL zu entsperren und Geld bis zu einer festlegbaren Höchstgrenze zu versenden.</string>
     <!-- Touch ID button title -->
     <string name="SecurityCenter.touchIdTitle">Touch ID</string>
     <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
     <!-- Balance: $4.00 -->
     <string name="Send.balance">Guthaben: %1$s</string>
     <!-- Instructions how to allow the camera access for the app -->
-    <string name="Send.cameraUnavailabeMessage.android">Erlauben Sie den Kamerazugriff unter „Einstellungen” &gt; „Apps” &gt; „Bread” &gt; „Berechtigungen”</string>
+    <string name="Send.cameraUnavailabeMessage.android">Erlauben Sie den Kamerazugriff unter „Einstellungen” &gt; „Apps” &gt; „HODL” &gt; „Berechtigungen”</string>
     <!-- Permission required to access camera -->
-    <string name="Send.cameraUnavailabeTitle.android">Bread hat keine Berechtigung für Kamerazugriff</string>
+    <string name="Send.cameraUnavailabeTitle.android">HODL hat keine Berechtigung für Kamerazugriff</string>
     <!-- Camera not allowed message -->
     <string name="Send.cameraunavailableMessage">Rufe die Einstellungen auf, um den Zugriff auf die Kamera zu erlauben.</string>
     <!-- Camera not allowed alert title -->
-    <string name="Send.cameraUnavailableTitle">Bread darf nicht auf die Kamera zugreifen</string>
+    <string name="Send.cameraUnavailableTitle">HODL darf nicht auf die Kamera zugreifen</string>
     <!-- Warning when sending to self. -->
     <string name="Send.containsAddress">Das Ziel ist deine eigene Adresse. Du kannst nichts an dich selbst senden.</string>
     <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
     <string name="Settings.currency">Anzeigewährung</string>
     <!-- Join Early access label -->
     <string name="Settings.earlyAccess">Zum Early Access anmelden</string>
-    <!-- Are you enjoying bread alert message body -->
-    <string name="Settings.enjoying">Gefällt dir Bread?</string>
+    <!-- Are you enjoying HODL alert message body -->
+    <string name="Settings.enjoying">Gefällt dir HODL?</string>
     <!-- Import wallet label -->
     <string name="Settings.importTitle">Wallet importieren</string>
     <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
     <!-- Get a legacy address menu label. -->
     <string name="Settings.legacyAddressTitle">Legacy-Adresse</string>
     <!-- Share data view body -->
-    <string name="ShareData.body">Hilf dabei, Bread zu verbessern, indem du uns deine Nutzungsdaten anonym übermittelst. Hiervon sind sämtliche Finanzinformationen ausgeschlossen. Wir respektieren deine finanzielle Privatsphäre.</string>
+    <string name="ShareData.body">Hilf dabei, HODL zu verbessern, indem du uns deine Nutzungsdaten anonym übermittelst. Hiervon sind sämtliche Finanzinformationen ausgeschlossen. Wir respektieren deine finanzielle Privatsphäre.</string>
     <!-- Share data header -->
     <string name="ShareData.header">Nutzungsdaten übermitteln?</string>
     <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
     <!-- button label -->
     <string name="StartPaperPhrase.againButtonTitle">Offlineschlüssel erneut notieren</string>
     <!-- Paper key explanation text. -->
-    <string name="StartPaperPhrase.body">Dein Offlineschlüssel ist die einzige Möglichkeit, dein Bread wiederherzustellen, falls du dein Smartphone verlierst, austauscht, es gestohlen wird oder kaputtgeht.\n\nHierfür zeigen wir dir eine Liste von Wörtern an, damit du sie dir auf ein Stück Papier notieren kannst, das es sicher aufzubewahren gilt.</string>
+    <string name="StartPaperPhrase.body">Dein Offlineschlüssel ist die einzige Möglichkeit, dein HODL wiederherzustellen, falls du dein Smartphone verlierst, austauscht, es gestohlen wird oder kaputtgeht.\n\nHierfür zeigen wir dir eine Liste von Wörtern an, damit du sie dir auf ein Stück Papier notieren kannst, das es sicher aufzubewahren gilt.</string>
     <!-- button label -->
     <string name="StartPaperPhrase.buttonTitle">Offlineschlüssel notieren</string>
     <!-- Argument is date -->
@@ -555,14 +555,14 @@
     <!-- Fingerprint Is Not Setup -->
     <string name="TouchIdSettings.disabledWarning.title.android">Fingerabdruck-Authentifizierung nicht aktiviert</string>
     <!-- Touch Id screen label -->
-    <string name="TouchIdSettings.label">Nutze deinen Fingerabdruck, um dein Bread zu entsperren und Geld bis zu einer festlegbaren Höchstgrenze zu versenden.</string>
+    <string name="TouchIdSettings.label">Nutze deinen Fingerabdruck, um dein HODL zu entsperren und Geld bis zu einer festlegbaren Höchstgrenze zu versenden.</string>
     <!-- Link Text (see TouchIdSettings.customizeText) -->
     <string name="TouchIdSettings.linkText">Bildschirm für Touch-ID-Ausgabenmaximum</string>
     <!-- Spending Limit: b100,000 ($100) -->
     <string name="TouchIdSettings.spendingLimit">Ausgabelimit: %1$s  (%2$s)</string>
     <!-- Touch id switch label. -->
-    <string name="TouchIdSettings.switchLabel">Touch ID für Bread aktivieren</string>
-    <!-- Enable fingerprint for this wallet called Bread -->
+    <string name="TouchIdSettings.switchLabel">Touch ID für HODL aktivieren</string>
+    <!-- Enable fingerprint for this wallet called HODL -->
     <string name="TouchIdSettings.switchLabel.android">Fingerabdruck-Authentifizierung aktivieren</string>
     <!-- Touch ID settings view title -->
     <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
     <!-- Instruction to touch the sensor for fingerprint authentication -->
     <string name="UnlockScreen.touchIdInstructions.android">Sensor berühren</string>
     <!-- TouchID prompt text -->
-    <string name="UnlockScreen.touchIdPrompt">Entsperre dein Bread.</string>
+    <string name="UnlockScreen.touchIdPrompt">Entsperre dein HODL.</string>
     <!-- Device authentication body -->
     <string name="UnlockScreen.touchIdPrompt.android">Bitte entsperren Sie Ihr Android-Gerät, um fortzufahren.</string>
     <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
     <!-- Update PIN caption text -->
     <string name="UpdatePin.caption">Merke dir diese PIN. Falls du sie vergisst, kannst du nicht mehr auf deine Bitcoins zugreifen.</string>
     <!-- PIN creation info. -->
-    <string name="UpdatePin.createInstruction">Deine PIN wird verwendet, um dein Bread zu entsperren und Geld zu versenden.</string>
+    <string name="UpdatePin.createInstruction">Deine PIN wird verwendet, um dein HODL zu entsperren und Geld zu versenden.</string>
     <!-- Update PIN title -->
     <string name="UpdatePin.createTitle">PIN festlegen</string>
     <!-- Update PIN title -->
@@ -703,7 +703,7 @@
     <!-- Authorize transaction with touch id message -->
     <string name="VerifyPin.touchIdMessage">Diese Transaktion genehmigen</string>
     <!-- 'No wallet' warning for watch app -->
-    <string name="Watch.noWalletWarning">Öffne die Bread-iPhone-App, um dein Wallet einzurichten.</string>
+    <string name="Watch.noWalletWarning">Öffne die HODL-iPhone-App, um dein Wallet einzurichten.</string>
     <!-- Dismiss button label -->
     <string name="Webview.dismiss">Verwerfen</string>
     <!-- Webview loading error message -->
@@ -711,11 +711,11 @@
     <!-- Updating webview message -->
     <string name="Webview.updating">Aktualisierung läuft …</string>
     <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-    <string name="Welcome.body">Breadwallet heißt jetzt Bread und hat ein brandneues Erscheinungsbild sowie einige neue Funktionen.\n\nWenn Sie Hilfe benötigen, halten Sie Ausschau nach dem (?), das auf den meisten Bildschirm oben rechts zu finden ist.</string>
+    <string name="Welcome.body">HODLwallet heißt jetzt HODL und hat ein brandneues Erscheinungsbild sowie einige neue Funktionen.\n\nWenn Sie Hilfe benötigen, halten Sie Ausschau nach dem (?), das auf den meisten Bildschirm oben rechts zu finden ist.</string>
     <!-- Top title of welcome screen -->
-    <string name="Welcome.title">Willkommen bei Bread!</string>
+    <string name="Welcome.title">Willkommen bei HODL!</string>
     <!-- Top title of segwit popup -->
-    <string name="Segwit.title"></string>
+    <string name="Segwit.title">HODL Wallet wurde aktualisiert!</string>
     <!-- Message of segwit popup -->
     <string name="Segwit.message"></string>
     <!-- Wipe wallet alert message -->
@@ -729,9 +729,9 @@
     <!-- Enter phrase to wipe wallet instruction. -->
     <string name="WipeWallet.instruction">Geben Sie die Wiederherstellungsphrase des Wallets ein, um es zu löschen und die Wiederherstellung eines anderen Wallets zu beginnen. Ihr aktueller Kontostand bleibt mit dieser Phrase verbunden.</string>
     <!-- Start wipe wallet view message -->
-    <string name="WipeWallet.startMessage">Das Anlegen oder Wiederherstellen einer weiteren Wallet ermöglicht es Ihnen, auf diesem Gerät auf eine andere Bread-Wallet zuzugreifen und diese zu verwalten.</string>
+    <string name="WipeWallet.startMessage">Das Anlegen oder Wiederherstellen einer weiteren Wallet ermöglicht es Ihnen, auf diesem Gerät auf eine andere HODL-Wallet zuzugreifen und diese zu verwalten.</string>
     <!-- Start wipe wallet view warning -->
-    <string name="WipeWallet.startWarning">Sie werden von diesem Gerät aus keinen Zugriff auf Ihr aktuelles Bread-Wallet mehr haben. Der Saldo verbleibt auf dem Satz.</string>
+    <string name="WipeWallet.startWarning">Sie werden von diesem Gerät aus keinen Zugriff auf Ihr aktuelles HODL-Wallet mehr haben. Der Saldo verbleibt auf dem Satz.</string>
     <!-- Wipe wallet navigation item title. -->
     <string name="WipeWallet.title">Ein anderes Wallet beginnen oder wiederherstellen</string>
     <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -510,6 +510,8 @@
     <string name="Settings.wallet">Wallet</string>
     <!-- Start or recover another wallet menu label. -->
     <string name="Settings.wipe">Ein anderes Wallet starten/wiederherstellen</string>
+    <!-- Show Legacy Address. -->
+    <string name="Settings.legacyAddress">Legacy-Adresse anzeigen</string>
     <!-- Share data view body -->
     <string name="ShareData.body">Hilf dabei, Bread zu verbessern, indem du uns deine Nutzungsdaten anonym übermittelst. Hiervon sind sämtliche Finanzinformationen ausgeschlossen. Wir respektieren deine finanzielle Privatsphäre.</string>
     <!-- Share data header -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blog</string>
   <!-- About screen footer -->
-  <string name="About.footer">Hecho por el equipo mundial de Bread. Versión %1$s</string>
+  <string name="About.footer">Hecho por el equipo mundial de HODL. Versión %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Política de privacidad</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Cargando cartera</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Mi Bread</string>
+  <string name="AccountHeader.defaultWalletName">Mi HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -35,7 +35,7 @@
   <!-- Keystore error -->
   <string name="Alert.keystore.generic.android">Hay un problema con el almacén de claves de tu sistema operativo Android. Ponte en contacto con support@breadwallet.com.</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Tus datos codificados en Bread fueron anulados recientemente debido a que no estaba habilitada tu pantalla de bloqueo de Android.</string>
+  <string name="Alert.keystore.invalidated.android">Tus datos codificados en HODL fueron anulados recientemente debido a que no estaba habilitada tu pantalla de bloqueo de Android.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Error de Android KeyStore</string>
   <!-- No internet alert message -->
@@ -199,13 +199,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Monedero por importar</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">Importar una cartera transfiere todo el dinero de tu otra carpeta a tu cartera de Bread mediante una sola transacción.</string>
+  <string name="Import.message">Importar una cartera transfiere todo el dinero de tu otra carpeta a tu cartera de HODL mediante una sola transacción.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Esta clave privada está protegida con una contraseña.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">contraseña</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Tu cartera Bread</string>
+  <string name="Import.rightCaption">Tu cartera HODL</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Escanear clave privada</string>
   <!-- Import wallet success alert title -->
@@ -225,9 +225,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Ignorar</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">SEGURIDAD DEL DISPOSITIVO COMPROMETIDA\nCualquier aplicación \"jailbreak\" puede acceder a los datos del llavero de Bread y robar tus bitcoins. Borra esta cartera de inmediato y restáurala en un dispositivo seguro.</string>
+  <string name="JailbreakWarnings.messageWithBalance">SEGURIDAD DEL DISPOSITIVO COMPROMETIDA\nCualquier aplicación \"jailbreak\" puede acceder a los datos del llavero de HODL y robar tus bitcoins. Borra esta cartera de inmediato y restáurala en un dispositivo seguro.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">SEGURIDAD DEL DISPOSITIVO COMPROMETIDA\nCualquier aplicación \"jailbreak\" puede acceder a los datos del llavero de Bread y robar tus bitcoins. Usa Bread únicamente en un dispositivo sin jailbreak.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">SEGURIDAD DEL DISPOSITIVO COMPROMETIDA\nCualquier aplicación \"jailbreak\" puede acceder a los datos del llavero de HODL y robar tus bitcoins. Usa HODL únicamente en un dispositivo sin jailbreak.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">AVISO</string>
   <!-- Wipe wallet button -->
@@ -235,7 +235,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Los servicios de ubicación están desactivados.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread no tiene permiso para acceder a los servicios de ubicación.</string>
+  <string name="LocationPlugin.notAuthorized">HODL no tiene permiso para acceder a los servicios de ubicación.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Has creado una cartera en %1$s</string>
   <!-- Manage wallet description text -->
@@ -313,7 +313,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transacción rechazada</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Ayuda a mejorar Bread compartiendo tus datos anónimos con nosotros</string>
+  <string name="Prompts.ShareData.body">Ayuda a mejorar HODL compartiendo tus datos anónimos con nosotros</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Compartir datos anónimos</string>
   <!-- Enable touch ID prompt body -->
@@ -327,11 +327,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread se ha actualizado y ahora utiliza un PIN de 6 dígitos. Toca aquí para actualizar.</string>
+  <string name="Prompts.UpgradePin.body">HODL se ha actualizado y ahora utiliza un PIN de 6 dígitos. Toca aquí para actualizar.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Actualizar PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Activa las notificaciones para recibir mensajes especiales de Bread en el futuro.</string>
+  <string name="PushNotifications.body">Activa las notificaciones para recibir mensajes especiales de HODL en el futuro.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Notificaciones push</string>
   <!-- Push notifications are off label -->
@@ -361,7 +361,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Introducir clave en papel</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Recupera tu Bread con la clave en papel.</string>
+  <string name="RecoverWallet.intro">Recupera tu HODL con la clave en papel.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">La clave en papel que acabas de introducir no es válida. Vuelve a comprobar cada palabra e inténtalo de nuevo.</string>
   <!-- Previous button accessibility label -->
@@ -389,7 +389,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minutos</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Si una transacción se muestra como completada en la red de bitcoin pero no en Bread.</string>
+  <string name="ReScan.body2">Si una transacción se muestra como completada en la red de bitcoin pero no en HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Obtienes un error repetidamente que dice que tu transacción ha sido rechazada.</string>
   <!-- Start Sync button label -->
@@ -419,13 +419,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Clave en papel</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Protege tu Bread de usuarios no autorizados.</string>
+  <string name="SecurityCenter.pinDescription">Protege tu HODL de usuarios no autorizados.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">PIN de 6 dígitos</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Centro de seguridad</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Desbloquea tu Bread de forma cómoda y envía dinero hasta un límite establecido.</string>
+  <string name="SecurityCenter.touchIdDescription">Desbloquea tu HODL de forma cómoda y envía dinero hasta un límite establecido.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -435,13 +435,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Saldo: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Para permitir el acceso a la cámara, ve a «Ajustes», selecciona «Aplicaciones», busca la aplicación «Bread» y selecciona la opción «Permisos»</string>
+  <string name="Send.cameraUnavailabeMessage.android">Para permitir el acceso a la cámara, ve a «Ajustes», selecciona «Aplicaciones», busca la aplicación «HODL» y selecciona la opción «Permisos»</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread no tiene permitido el acceso a la cámara</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL no tiene permitido el acceso a la cámara</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Ve a Ajustes para activar el acceso a la cámara.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread no tiene permisos para acceder a la cámara</string>
+  <string name="Send.cameraUnavailableTitle">HODL no tiene permisos para acceder a la cámara</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">El destino es tu propia dirección. No puedes hacerte un envío a ti mismo.</string>
   <!-- Could not create transaction alert title -->
@@ -496,8 +496,8 @@
   <string name="Settings.currency">Mostrar moneda</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Únete al acceso anticipado</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">¿Te gusta Bread?</string>
+  <!-- Are you enjoying hodl alert message body -->
+  <string name="Settings.enjoying">¿Te gusta HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importar cartera</string>
   <!-- Manage settings section header -->
@@ -521,9 +521,11 @@
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Iniciar/recuperar otra cartera</string>
   <!-- Show Legacy Address. -->
-  <string name="Settings.legacyAddress">Mostrar dirección de legado</string>
+  <string name="Settings.legacyAddress">Mostrar dirección antigua</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Dirección Antigua</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Ayuda a mejorar Bread compartiendo tus datos anónimos con nosotros. Esto no incluye ninguna información financiera. Respetamos tu privacidad financiera.</string>
+  <string name="ShareData.body">Ayuda a mejorar HODL compartiendo tus datos anónimos con nosotros. Esto no incluye ninguna información financiera. Respetamos tu privacidad financiera.</string>
   <!-- Share data header -->
   <string name="ShareData.header">¿Compartir datos?</string>
   <!-- Share data switch label. -->
@@ -531,7 +533,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Apunta nuevamente la clave en papel</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Tu clave de papel es la única manera de restaurar tu Bread si pierdes tu teléfono, o te lo roban, se rompe o se actualiza.\n\nTe mostraremos una lista de palabras para apuntar en un trozo de papel y guardarlo en un sitio seguro.</string>
+  <string name="StartPaperPhrase.body">Tu clave de papel es la única manera de restaurar tu HODL si pierdes tu teléfono, o te lo roban, se rompe o se actualiza.\n\nTe mostraremos una lista de palabras para apuntar en un trozo de papel y guardarlo en un sitio seguro.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Apuntar la clave en papel</string>
   <!-- Argument is date -->
@@ -563,14 +565,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">La autenticación por huellas digitales no está habilitada</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Utiliza tu huella digital para desbloquear Bread y enviar dinero hasta un límite establecido.</string>
+  <string name="TouchIdSettings.label">Utiliza tu huella digital para desbloquear HODL y enviar dinero hasta un límite establecido.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Pantalla de límite de gasto del Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Límite de gasto: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Activa Touch ID para Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Activa Touch ID para HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Habilita la autenticación por huellas digitales</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -673,7 +675,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Toca el sensor</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Desbloquea tu Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Desbloquea tu HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Desbloquea tu dispositivo Android para continuar.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -685,7 +687,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Recuerda este PIN. Si lo olvidas, no podrás acceder a tu bitcoin.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Tu PIN se usará para desbloquear Bread y enviar dinero.</string>
+  <string name="UpdatePin.createInstruction">Tu PIN se usará para desbloquear HODL y enviar dinero.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Establecer PIN</string>
   <!-- Update PIN title -->
@@ -719,7 +721,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Autorizar esta transacción</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Abre la aplicación Bread en iPhone para configurar tu cartera.</string>
+  <string name="Watch.noWalletWarning">Abre la aplicación HODL en iPhone para configurar tu cartera.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Descartar</string>
   <!-- Webview loading error message -->
@@ -727,9 +729,13 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Actualizando...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet ha cambiado su nombre por el de Bread, con un nuevo aspecto y algunas características nuevas.\n\nSi necesitas ayuda, busca el (?) en la parte superior derecha de la mayoría de las pantallas.</string>
+  <string name="Welcome.body">Un nuevo aspecto y algunas características nuevas.\n\nSi necesitas ayuda, busca el (?) en la parte superior derecha de la mayoría de las pantallas.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">¡Bienvenido a Bread!</string>
+  <string name="Welcome.title">¡Bienvenido a HODL!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title">HODL Wallet se ha Actualizado!</string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message">HODL Wallet se ha actualizado al estándar de dirección de Bitcoin más reciente. Esto te brinda el beneficio adicional de ahorrar en las tarifas de transacción y ser compatible con los últimos estándares de la Red Bitcoin. No tienes que hacer nada diferente y lo único que notarás es que tus direcciones han cambiado y ahora comienzan con \"btc\".\n\nTu dinero está seguro y aún se almacena en tu Clave de Recuperación.\n\nDado que este cambio aún está teniendo efecto en la Red Bitcoin, es posible que algunos servicios no estén listos para enviar a este nuevo tipo de dirección. Si te encuentras con esto, aún puedes acceder a las direcciones antiguas que comienzan con \"1\" a través de: Configuración / Cartera / Mostrar direcciones antiguas.\n\nLegacy address: Dirección antigua</string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">¿Seguro que quieres eliminar esta cartera?</string>
   <!-- Wipe wallet alert title -->
@@ -741,9 +747,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Introduce la frase de recuperación de esta cartera para borrarla y comenzar o recuperar otra. Tu saldo actual sigue en esta frase.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Iniciar o recuperar otra cartera te permite acceder y administrar una cartera de Bread diferente en este dispositivo.</string>
+  <string name="WipeWallet.startMessage">Iniciar o recuperar otra cartera te permite acceder y administrar una cartera de HODL diferente en este dispositivo.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Ya no podrás acceder a tu cartera Bread actual desde este dispositivo. El saldo se mantendrá en la frase.</string>
+  <string name="WipeWallet.startWarning">Ya no podrás acceder a tu cartera HODL actual desde este dispositivo. El saldo se mantendrá en la frase.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Comenzar o recuperar otra cartera</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -33,7 +33,7 @@
   <!-- Error alert title -->
   <string name="Alert.error">Error</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Hay un problema con el almacén de claves de tu sistema operativo Android. Ponte en contacto con support@breadwallet.com.</string>
+  <string name="Alert.keystore.generic.android">Hay un problema con el almacén de claves de tu sistema operativo Android. Ponte en contacto con support@hodlwallet.co.</string>
   <!-- KeyStore error, keys are invalidated -->
   <string name="Alert.keystore.invalidated.android">Tus datos codificados en HODL fueron anulados recientemente debido a que no estaba habilitada tu pantalla de bloqueo de Android.</string>
   <!-- Keystore error title -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -520,6 +520,8 @@
   <string name="Settings.wallet">Cartera</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Iniciar/recuperar otra cartera</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Mostrar dirección de legado</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Ayuda a mejorar Bread compartiendo tus datos anónimos con nosotros. Esto no incluye ninguna información financiera. Respetamos tu privacidad financiera.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Portefeuille</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Démarrer/récupérer un autre portefeuille</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Voir la Legacy adresse</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Aidez à améliorer Bread en partageant vos données anonymes avec nous. Cela n\'inclut aucune information financière. Nous respectons votre confidentialité financière.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blogue</string>
   <!-- About screen footer -->
-  <string name="About.footer">Fait par l\'équipe mondiale de Bread. Version %1$s</string>
+  <string name="About.footer">Fait par l\'équipe mondiale de HODL. Version %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Politique de confidentialité</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Chargement du portefeuille</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Mon Bread</string>
+  <string name="AccountHeader.defaultWalletName">Mon HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Erreur</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Un problème est survenu avec votre keystore Android OS, veuillez contacter support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Un problème est survenu avec votre keystore Android OS, veuillez contacter support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Vos données cryptées de Bread ont été récemment invalidées, car le verrouillage de l\'écran de votre appareil Android a été désactivé.</string>
+  <string name="Alert.keystore.invalidated.android">Vos données cryptées de HODL ont été récemment invalidées, car le verrouillage de l\'écran de votre appareil Android a été désactivé.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Erreur avec le KeyStore Android</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Portefeuille à importer</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">L\'importation d\'un portefeuille transfère tout l\'argent de votre autre portefeuille vers votre portefeuille Bread avec une seule transaction.</string>
+  <string name="Import.message">L\'importation d\'un portefeuille transfère tout l\'argent de votre autre portefeuille vers votre portefeuille HODL avec une seule transaction.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Cette clé privée est protégée par mot de passe.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">mot de passe</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Votre portefeuille de Bread</string>
+  <string name="Import.rightCaption">Votre portefeuille de HODL</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Scanner la clé privée</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Ignorer</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">SÉCURITÉ DU DISPOSITIF COMPROMISE\n  Toute application « évasive » peut accéder aux données du porte-clé de Bread et voler vos bitcoins ! Détruisez ce portefeuille immédiatement et restaurez-le sur un appareil sécurisé.</string>
+  <string name="JailbreakWarnings.messageWithBalance">SÉCURITÉ DU DISPOSITIF COMPROMISE\n  Toute application « évasive » peut accéder aux données du porte-clé de HODL et voler vos bitcoins ! Détruisez ce portefeuille immédiatement et restaurez-le sur un appareil sécurisé.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">SÉCURITÉ DU DISPOSITIF COMPROMISE\n  Toute application « évasive » peut accéder aux données du porte-clé de Bread et voler vos bitcoins. N\'utilisez Bread que sur un appareil non évasif.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">SÉCURITÉ DU DISPOSITIF COMPROMISE\n  Toute application « évasive » peut accéder aux données du porte-clé de HODL et voler vos bitcoins. N\'utilisez HODL que sur un appareil non évasif.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">AVERTISSEMENT</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Les services de localisation sont désactivés.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread n\'a pas l\'autorisation d\'accéder aux services de localisation.</string>
+  <string name="LocationPlugin.notAuthorized">HODL n\'a pas l\'autorisation d\'accéder aux services de localisation.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Vous avez créé votre portefeuille sur %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transaction rejetée</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Aidez à améliorer Bread en partageant vos données anonymes avec nous</string>
+  <string name="Prompts.ShareData.body">Aidez à améliorer HODL en partageant vos données anonymes avec nous</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Partager les données anonymes</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread a été mis à niveau pour utiliser un code PIN à six chiffres. Appuyez ici pour mettre à niveau.</string>
+  <string name="Prompts.UpgradePin.body">HODL a été mis à niveau pour utiliser un code PIN à six chiffres. Appuyez ici pour mettre à niveau.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Mettre à jour le code PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Activez les notifications pour recevoir des messages spéciaux de Bread à l\'avenir.</string>
+  <string name="PushNotifications.body">Activez les notifications pour recevoir des messages spéciaux de HODL à l\'avenir.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Notifications push</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Entrez la clé de papier</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Récupérez votre Bread avec votre clé de papier.</string>
+  <string name="RecoverWallet.intro">Récupérez votre HODL avec votre clé de papier.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">La clé de papier saisie n\'est pas valide. Revérifiez chaque mot et réessayez.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minutes</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Si une transaction apparaît comme achevée sur le réseau de bitcoin mais pas dans votre Bread.</string>
+  <string name="ReScan.body2">Si une transaction apparaît comme achevée sur le réseau de bitcoin mais pas dans votre HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Vous recevez de manière répétée un message d\'erreur vous informant du rejet de votre transaction.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Clé de papier</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Protège votre Bread contre les utilisateurs non autorisés.</string>
+  <string name="SecurityCenter.pinDescription">Protège votre HODL contre les utilisateurs non autorisés.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">PIN à six chiffres</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Centre de sécurité</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Débloquez convenablement votre Bread et envoyez de l\'argent jusqu\'à une limite définie.</string>
+  <string name="SecurityCenter.touchIdDescription">Débloquez convenablement votre HODL et envoyez de l\'argent jusqu\'à une limite définie.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Solde : %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Autoriser l\'accès à l\'appareil photo en allant dans « Paramètres » &gt; « Apps » &gt; « Bread » &gt; « Permissions »</string>
+  <string name="Send.cameraUnavailabeMessage.android">Autoriser l\'accès à l\'appareil photo en allant dans « Paramètres » &gt; « Apps » &gt; « HODL » &gt; « Permissions »</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread n\'est pas autorisé à accéder à l\'appareil photo</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL n\'est pas autorisé à accéder à l\'appareil photo</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Accédez à Paramètres pour autoriser l\'accès à la caméra.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread n\'est pas autorisé à accéder à la caméra</string>
+  <string name="Send.cameraUnavailableTitle">HODL n\'est pas autorisé à accéder à la caméra</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">La destination est votre propre adresse. Vous ne pouvez pas envoyer à vous même.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Afficher la devise</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Rejoignez l\'accès anticipé</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Vous aimez Bread ?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Vous aimez HODL ?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importer le portefeuille</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">Legacy Adresse</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Aidez à améliorer Bread en partageant vos données anonymes avec nous. Cela n\'inclut aucune information financière. Nous respectons votre confidentialité financière.</string>
+  <string name="ShareData.body">Aidez à améliorer HODL en partageant vos données anonymes avec nous. Cela n\'inclut aucune information financière. Nous respectons votre confidentialité financière.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Partager les données ?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Enregistrez la clé de papier à nouveau</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Votre clé de papier est la seule façon de restaurer votre Bread si votre téléphone est perdu, volé, cassé ou mis à niveau.\n\nNous vous montrerons une liste de mots à écrire sur un morceau de papier et à garder en sécurité.</string>
+  <string name="StartPaperPhrase.body">Votre clé de papier est la seule façon de restaurer votre HODL si votre téléphone est perdu, volé, cassé ou mis à niveau.\n\nNous vous montrerons une liste de mots à écrire sur un morceau de papier et à garder en sécurité.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Écrire la clé de papier</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">L\'identification par empreinte digitale n\'est pas activée</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Utilisez votre empreinte digitale pour débloquer votre Bread et envoyer de l\'argent jusqu\'à une limite définie.</string>
+  <string name="TouchIdSettings.label">Utilisez votre empreinte digitale pour débloquer votre HODL et envoyer de l\'argent jusqu\'à une limite définie.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Écran de plafond de dépenses Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Limite de dépenses : %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Activer Touch ID pour Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Activer Touch ID pour HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Activer l\'identification par empreinte digitale</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Appuyez sur le capteur</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Déverrouillez votre Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Déverrouillez votre HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Veuillez déverrouiller votre appareil Android pour continuer.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Souvenez-vous de ce code PIN. Si vous l\'oubliez, vous ne pourrez pas accéder à votre bitcoin.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Votre NIP sera utilisé pour débloquer votre Bread et envoyer de l\'argent.</string>
+  <string name="UpdatePin.createInstruction">Votre NIP sera utilisé pour débloquer votre HODL et envoyer de l\'argent.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Définir PIN</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Autoriser cette transaction</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Ouvrez l\'application Bread pour iPhone pour configurer votre portefeuille.</string>
+  <string name="Watch.noWalletWarning">Ouvrez l\'application HODL pour iPhone pour configurer votre portefeuille.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Rejeter</string>
   <!-- Webview loading error message -->
@@ -711,11 +711,11 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Mise à jour...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet revient sous le nom de Bread, avec un nouveau design et de nouvelles fonctionnalités. \n\nSi vous avez besoin d\'aide, cliquez sur le (?) en haut à droite de la plupart des écrans.</string>
+  <string name="Welcome.body">HODLwallet revient sous le nom de HODL, avec un nouveau design et de nouvelles fonctionnalités. \n\nSi vous avez besoin d\'aide, cliquez sur le (?) en haut à droite de la plupart des écrans.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Bienvenue chez Bread !</string>
+  <string name="Welcome.title">Bienvenue chez HODL !</string>
   <!-- Top title of segwit popup -->
-  <string name="Segwit.title"></string>
+  <string name="Segwit.title">Le portefeuille HODL a été amélioré!</string>
   <!-- Message of segwit popup -->
   <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Soumettez la phrase de récupération de ce portefeuille pour l\'effacer et commencer à en récupérer un autre. Votre solde actuel demeure sur cette phrase.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">L\'ouverture ou la récupération d\'un autre portefeuille vous permet d\'accéder et de gérer différents portefeuilles Bread depuis cet appareil.</string>
+  <string name="WipeWallet.startMessage">L\'ouverture ou la récupération d\'un autre portefeuille vous permet d\'accéder et de gérer différents portefeuilles HODL depuis cet appareil.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Vous ne pourrez plus accéder à votre portefeuille Bread depuis cet appareil. Le solde restera inchangé.</string>
+  <string name="WipeWallet.startWarning">Vous ne pourrez plus accéder à votre portefeuille HODL depuis cet appareil. Le solde restera inchangé.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Commencer un nouveau portefeuille ou récupérer un autre portefeuille</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">Démarrer/récupérer un autre portefeuille</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">Voir la Legacy adresse</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Legacy Adresse</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Aidez à améliorer Bread en partageant vos données anonymes avec nous. Cela n\'inclut aucune information financière. Nous respectons votre confidentialité financière.</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwallet revient sous le nom de Bread, avec un nouveau design et de nouvelles fonctionnalités. \n\nSi vous avez besoin d\'aide, cliquez sur le (?) en haut à droite de la plupart des écrans.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Bienvenue chez Bread !</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Souhaitez-vous vraiment supprimer ce portefeuille ?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Portafogli</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Inizia/Recupera un altro portafogli</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Visualizza indirizzo Legacy</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Aiuta a migliorare Bread condividendo con noi i tuoi dati anonimi. Ciò non include alcuna informazione finanziaria. Rispettiamo la tua privacy finanziaria.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blog</string>
   <!-- About screen footer -->
-  <string name="About.footer">Realizzato dal team globale Bread. Versione %1$s</string>
+  <string name="About.footer">Realizzato dal team globale HODL. Versione %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Informativa sulla Privacy</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Caricamento Portafoglio</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Il Mio Bread</string>
+  <string name="AccountHeader.defaultWalletName">Il Mio HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Errore</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">C’è un problema con il portachiavi del tuo sistema operativo Android, per favore, contatta support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">C’è un problema con il portachiavi del tuo sistema operativo Android, per favore, contatta support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">I tuoi dati criptati di Bread sono stati invalidati recentemente perché la schermata di blocco del tuo Android era disabilitata.</string>
+  <string name="Alert.keystore.invalidated.android">I tuoi dati criptati di HODL sono stati invalidati recentemente perché la schermata di blocco del tuo Android era disabilitata.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Errore Portachiavi Android</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Portafoglio da importare</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">L\'importazione di un portafoglio trasferisce tutto il denaro dal tuo altro portafoglio al portafoglio Bread utilizzando una singola transazione.</string>
+  <string name="Import.message">L\'importazione di un portafoglio trasferisce tutto il denaro dal tuo altro portafoglio al portafoglio HODL utilizzando una singola transazione.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Questa chiave privata è protetta da password.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">password</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Il Tuo Portafoglio Bread</string>
+  <string name="Import.rightCaption">Il Tuo Portafoglio HODL</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Acquisisci Chiave Privata</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Ignora</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">SICUREZZA DEL DISPOSITIVO COMPROMESSA\nQualsiasi applicazione \"jailbreak\" può accedere ai dati di keychain di Bread e rubarti i bitcoin! Cancella immediatamente questo portafoglio ed effettua il ripristino su un dispositivo sicuro.</string>
+  <string name="JailbreakWarnings.messageWithBalance">SICUREZZA DEL DISPOSITIVO COMPROMESSA\nQualsiasi applicazione \"jailbreak\" può accedere ai dati di keychain di HODL e rubarti i bitcoin! Cancella immediatamente questo portafoglio ed effettua il ripristino su un dispositivo sicuro.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">SICUREZZA DEL DISPOSITIVO COMPROMESSA\nQualsiasi applicazione \"jailbreak\" può accedere ai dati di keychain di Bread e rubarti i bitcoin. Utilizza Bread solamente su un dispositivo senza jailbreak.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">SICUREZZA DEL DISPOSITIVO COMPROMESSA\nQualsiasi applicazione \"jailbreak\" può accedere ai dati di keychain di HODL e rubarti i bitcoin. Utilizza HODL solamente su un dispositivo senza jailbreak.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">ATTENZIONE</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">I servizi di localizzazione sono disabilitati.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread non dispone dell\'autorizzazione per accedere ai servizi di localizzazione.</string>
+  <string name="LocationPlugin.notAuthorized">HODL non dispone dell\'autorizzazione per accedere ai servizi di localizzazione.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Hai creato il tuo portafoglio il %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transazione Rifiutata</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Aiutaci a migliorare Bread condividendo i tuoi dati con noi anonimamente</string>
+  <string name="Prompts.ShareData.body">Aiutaci a migliorare HODL condividendo i tuoi dati con noi anonimamente</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Condividi dati anonimamente</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread è stato aggiornato all\'utilizzo di un PIN a 6 cifre. Tocca qui per aggiornare.</string>
+  <string name="Prompts.UpgradePin.body">HODL è stato aggiornato all\'utilizzo di un PIN a 6 cifre. Tocca qui per aggiornare.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Aggiorna il PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Attiva le notifiche per ricevere messaggi speciali da Bread in futuro.</string>
+  <string name="PushNotifications.body">Attiva le notifiche per ricevere messaggi speciali da HODL in futuro.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Notifiche Push</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Inserisci Chiave Cartacea</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Recupera il tuo Bread con la tua chiave cartacea.</string>
+  <string name="RecoverWallet.intro">Recupera il tuo HODL con la tua chiave cartacea.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">La chiave cartacea inserita non è valida. Si prega di controllare ogni parola due volte e riprovare.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minuti</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Se una transazione figura come completata sulla rete bitcoin, ma non sul tuo Bread.</string>
+  <string name="ReScan.body2">Se una transazione figura come completata sulla rete bitcoin, ma non sul tuo HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Hai ricevuto ripetutamente un errore che dice che la transazione è stata rifiutata.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Chiave Cartacea</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Protegge il tuo Bread dagli utenti non autorizzati.</string>
+  <string name="SecurityCenter.pinDescription">Protegge il tuo HODL dagli utenti non autorizzati.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">PIN a 6 cifre</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Centro Sicurezza</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Sblocca comodamente il tuo Bread e invia denaro fino a un limite impostato.</string>
+  <string name="SecurityCenter.touchIdDescription">Sblocca comodamente il tuo HODL e invia denaro fino a un limite impostato.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Saldo: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Consenti l’accesso alla fotocamera in “Impostazioni” &gt; “Apps” &gt; “Bread” &gt; “Permessi”</string>
+  <string name="Send.cameraUnavailabeMessage.android">Consenti l’accesso alla fotocamera in “Impostazioni” &gt; “Apps” &gt; “HODL” &gt; “Permessi”</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">L’accesso alla fotocamera non è consentito a Bread.</string>
+  <string name="Send.cameraUnavailabeTitle.android">L’accesso alla fotocamera non è consentito a HODL.</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Vai su Impostazioni per consentire l\'accesso alla fotocamera.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread non è autorizzato ad accedere alla fotocamera</string>
+  <string name="Send.cameraUnavailableTitle">HODL non è autorizzato ad accedere alla fotocamera</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">La destinazione corrisponde al tuo indirizzo. Non puoi inviare a te stesso.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Visualizza valuta</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Iscriviti all\'Accesso Immediato</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Ti piace Bread?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Ti piace HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importa Portafoglio</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">Indirizzo Legacy</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Aiuta a migliorare Bread condividendo con noi i tuoi dati anonimi. Ciò non include alcuna informazione finanziaria. Rispettiamo la tua privacy finanziaria.</string>
+  <string name="ShareData.body">Aiuta a migliorare HODL condividendo con noi i tuoi dati anonimi. Ciò non include alcuna informazione finanziaria. Rispettiamo la tua privacy finanziaria.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Condividi Dati?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Annota la Chiave Cartacea di nuovo</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">La tua chiave cartacea è l\'unico modo per ripristinare il tuo Bread, nel caso il tuo telefono sia perso, rubato, rotto o aggiornato.\n\nTi mostreremo un elenco di parole da annotare su un pezzo di carta e conservare al sicuro.</string>
+  <string name="StartPaperPhrase.body">La tua chiave cartacea è l\'unico modo per ripristinare il tuo HODL, nel caso il tuo telefono sia perso, rubato, rotto o aggiornato.\n\nTi mostreremo un elenco di parole da annotare su un pezzo di carta e conservare al sicuro.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Annota la Chiave Cartacea</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Autenticazione Impronta non abilitata</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Utilizza l\'impronta digitale per sbloccare il tuo Bread e inviare denaro fino a un limite impostato.</string>
+  <string name="TouchIdSettings.label">Utilizza l\'impronta digitale per sbloccare il tuo HODL e inviare denaro fino a un limite impostato.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Schermata limite di spesa con Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Limite di spesa: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Abilita Touch ID per Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Abilita Touch ID per HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Abilita l’Autenticazione con Impronta Digitale</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Sensore Touch</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Sblocca il tuo Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Sblocca il tuo HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Per favore, sblocca il tuo dispositivo Android per continuare.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Ricorda questo PIN. Se lo dimentichi, non sarai in grado di accedere al tuo bitcoin.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Il PIN verrà utilizzato per sbloccare il tuo Bread e inviare denaro.</string>
+  <string name="UpdatePin.createInstruction">Il PIN verrà utilizzato per sbloccare il tuo HODL e inviare denaro.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Imposta PIN</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Autorizza questa transazione</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Apri l\'app Bread per iPhone per impostare tuo il portafoglio.</string>
+  <string name="Watch.noWalletWarning">Apri l\'app HODL per iPhone per impostare tuo il portafoglio.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Ignora</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,13 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">In aggiornamento…</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet ha cambiato il suo nome in Bread e ha un look nuovissimo nonché alcune nuove funzionalità.\n\nSe hai bisogno di aiuto, cerca il (?) a destra in alto sulla maggior parte delle schermate.</string>
+  <string name="Welcome.body">HODLwallet ha cambiato il suo nome in HODL e ha un look nuovissimo nonché alcune nuove funzionalità.\n\nSe hai bisogno di aiuto, cerca il (?) a destra in alto sulla maggior parte delle schermate.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Ti diamo il benvenuto su Bread!</string>
+  <string name="Welcome.title">Ti diamo il benvenuto su HODL!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title">HODL Wallet è aggiornato!</string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Sicuro di voler eliminare questo portafogli?</string>
   <!-- Wipe wallet alert title -->
@@ -725,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Inserisci la frase di recupero di questo portafogli per ripulirlo o recuperane un\'altra. Il tuo saldo rimane in questa frase.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Iniziare o recuperare un altro portafoglio ti consente di avere accesso e gestire un portafoglio Bread diverso su questo dispositivo.</string>
+  <string name="WipeWallet.startMessage">Iniziare o recuperare un altro portafoglio ti consente di avere accesso e gestire un portafoglio HODL diverso su questo dispositivo.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Non sarai più in grado di accedere al tuo portafoglio Bread attuale da questo dispositivo. Il saldo resterà solo un modo di dire.</string>
+  <string name="WipeWallet.startWarning">Non sarai più in grado di accedere al tuo portafoglio HODL attuale da questo dispositivo. Il saldo resterà solo un modo di dire.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Inizia o recupera un altro portafogli.</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">Inizia/Recupera un altro portafogli</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">Visualizza indirizzo Legacy</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Indirizzo Legacy</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Aiuta a migliorare Bread condividendo con noi i tuoi dati anonimi. Ciò non include alcuna informazione finanziaria. Rispettiamo la tua privacy finanziaria.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">別のウォレットを作成、または復元する</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">従来のアドレスを表示します。</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">レガシーアドレス</string>
   <!-- Share data view body -->
   <string name="ShareData.body">匿名データをシェアして、ブレッドの改善にご協力ください。これにはいかなる財務情報も含まれません。私たちはあなたの財務プライバシーを尊重しています。</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwalletは新しい見た目と新機能を備えて、Breadという名前に生まれ変わりました。\n\nヘルプをご覧になるには、ほとんどの画面の右上にある(?)をお探しください。</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Breadへようこそ！</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">本当にこのウォレットを削除しますか？</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">ウォレット</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">別のウォレットを作成、または復元する</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">従来のアドレスを表示します。</string>
   <!-- Share data view body -->
   <string name="ShareData.body">匿名データをシェアして、ブレッドの改善にご協力ください。これにはいかなる財務情報も含まれません。私たちはあなたの財務プライバシーを尊重しています。</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">ブレッド</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">ブログ</string>
   <!-- About screen footer -->
@@ -33,7 +33,7 @@
   <!-- Error alert title -->
   <string name="Alert.error">エラー</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Android OSのKeystoreに問題があります。support@breadwallet.com にお問い合わせください。</string>
+  <string name="Alert.keystore.generic.android">Android OSのKeystoreに問題があります。support@hodlwallet.co にお問い合わせください。</string>
   <!-- KeyStore error, keys are invalidated -->
   <string name="Alert.keystore.invalidated.android">お使いのAndroidロック画面が無効にされたため、暗号化されたブレッドのデータはつい最近無効になりました。</string>
   <!-- Keystore error title -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">トランザクションが拒否されました</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">匿名のデータを共有してBreadの機能向上に役立てる</string>
+  <string name="Prompts.ShareData.body">匿名のデータを共有してHODLの機能向上に役立てる</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">匿名のデータを共有する</string>
   <!-- Enable touch ID prompt body -->
@@ -321,7 +321,7 @@
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">PINコードを更新する</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">今後、Breadからの特別なメッセージを受け取るために通知をオンにしてください。</string>
+  <string name="PushNotifications.body">今後、HODLからの特別なメッセージを受け取るために通知をオンにしてください。</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">プッシュ通知</string>
   <!-- Push notifications are off label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20〜45分</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">ビットコインネットワークでトランザクションが完了したと表示されているが、Bread上では完了と表示されない場合。</string>
+  <string name="ReScan.body2">ビットコインネットワークでトランザクションが完了したと表示されているが、HODL上では完了と表示されない場合。</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">送金しているが、拒否され続けている場合。</string>
   <!-- Start Sync button label -->
@@ -415,7 +415,7 @@
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">セキュリティセンター</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Breadロック解除の他、設定した限度額までの送金も指紋認証で出来ます。</string>
+  <string name="SecurityCenter.touchIdDescription">HODLロック解除の他、設定した限度額までの送金も指紋認証で出来ます。</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -486,7 +486,7 @@
   <string name="Settings.currency">表示される通貨</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">早期アクセスに参加</string>
-  <!-- Are you enjoying bread alert message body -->
+  <!-- Are you enjoying HODL alert message body -->
   <string name="Settings.enjoying">ブレッドをお楽しみいただいていますか?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">ウォレットをインポート</string>
@@ -562,7 +562,7 @@
   <string name="TouchIdSettings.spendingLimit">利用限度: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
   <string name="TouchIdSettings.switchLabel">ブレッドでTouch IDの有効化</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">指紋認証を有効にする</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">このトランザクションを認証する</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">BreadのiPhoneアプリを開き、ウォレットをセットアップする</string>
+  <string name="Watch.noWalletWarning">HODLのiPhoneアプリを開き、ウォレットをセットアップする</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">解除</string>
   <!-- Webview loading error message -->
@@ -711,11 +711,11 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">更新中...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwalletは新しい見た目と新機能を備えて、Breadという名前に生まれ変わりました。\n\nヘルプをご覧になるには、ほとんどの画面の右上にある(?)をお探しください。</string>
+  <string name="Welcome.body">HODLwalletは新しい見た目と新機能を備えて、HODLという名前に生まれ変わりました。\n\nヘルプをご覧になるには、ほとんどの画面の右上にある(?)をお探しください。</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Breadへようこそ！</string>
+  <string name="Welcome.title">HODLへようこそ！</string>
   <!-- Top title of segwit popup -->
-  <string name="Segwit.title"></string>
+  <string name="Segwit.title">HODL Walletがアップグレードしました！</string>
   <!-- Message of segwit popup -->
   <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">ウォレットを消去し、新しいウォレットを作成したり、復元したりしたい場合は復旧フレーズを入力してください。この段階では残高は残っています。</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">別のウォレットを開設するか復元することにより、このデバイス上で異なるBreadウォレットへのアクセスと管理ができるようになります。</string>
+  <string name="WipeWallet.startMessage">別のウォレットを開設するか復元することにより、このデバイス上で異なるHODLウォレットへのアクセスと管理ができるようになります。</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">このデバイスから現在使用中のBreadウォレットへのアクセスはできなくなります。残高はフレーズに残されます。</string>
+  <string name="WipeWallet.startWarning">このデバイスから現在使用中のHODLウォレットへのアクセスはできなくなります。残高はフレーズに残されます。</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">別のウォレットを作成、または復元する</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">블로그</string>
   <!-- About screen footer -->
-  <string name="About.footer">글로벌 Bread 팀 제작. 버전 %1$s</string>
+  <string name="About.footer">글로벌 HODL 팀 제작. 버전 %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">개인정보 보호정책</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">지갑 로딩</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">나의 Bread</string>
+  <string name="AccountHeader.defaultWalletName">나의 HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,7 +33,7 @@
   <!-- Error alert title -->
   <string name="Alert.error">오류</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">귀하의 안드로이드 OS 키스토어에 문제가 있습니다, support@breadwallet.com로 연락해 주세요</string>
+  <string name="Alert.keystore.generic.android">귀하의 안드로이드 OS 키스토어에 문제가 있습니다, support@hodlwallet.co로 연락해 주세요</string>
   <!-- KeyStore error, keys are invalidated -->
   <string name="Alert.keystore.invalidated.android">귀하의 안드로이드 잠금 화면이 꺼져서 귀하의 암호화 된 데이터가 최근 무효화 되었습니다.</string>
   <!-- Keystore error title -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">불러오기 할 지갑</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">지갑 불러오기는 단일 거래를 사용하여 귀하의 다른 지갑으로부터 귀하의 Bread 지갑으로 모든 돈을 송금합니다.</string>
+  <string name="Import.message">지갑 불러오기는 단일 거래를 사용하여 귀하의 다른 지갑으로부터 귀하의 HODL 지갑으로 모든 돈을 송금합니다.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">이 개인 열쇠는 비밀번호로 보호됩니다.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">비밀번호</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">귀하의 Bread 지갑</string>
+  <string name="Import.rightCaption">귀하의 HODL 지갑</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">개인 열쇠 스캔</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">무시</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">장치 보안 취약\n모든 \'jailbreak\' 앱이 Bread의 키체인 데이터에 접속하여 귀하의 비트코인을 훔칠 수 있습니다! 이 지갑을 바로 지우시고 안전한 장치에서 복구하세요.</string>
+  <string name="JailbreakWarnings.messageWithBalance">장치 보안 취약\n모든 \'jailbreak\' 앱이 HODL의 키체인 데이터에 접속하여 귀하의 비트코인을 훔칠 수 있습니다! 이 지갑을 바로 지우시고 안전한 장치에서 복구하세요.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">장치 보안 취약\n모든 \'jailbreak\' 앱이 Bread의 키체인 데이터에 접속하여 귀하의 비트코인을 훔칠 수 있습니다! Bread를 비-jailbroken 장치에서만 사용해 주세요.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">장치 보안 취약\n모든 \'jailbreak\' 앱이 HODL의 키체인 데이터에 접속하여 귀하의 비트코인을 훔칠 수 있습니다! HODL를 비-jailbroken 장치에서만 사용해 주세요.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">경고</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">위치 서비스가 꺼졌습니다.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread가 위치 서비스 접속 권한이 없습니다.</string>
+  <string name="LocationPlugin.notAuthorized">HODL가 위치 서비스 접속 권한이 없습니다.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">귀하께서는 %1$s 에 지갑을 만들었습니다</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">거래 거절됨</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Bread가 발전할 수 있도록 익명 데이터를 공유해주십시오</string>
+  <string name="Prompts.ShareData.body">HODL가 발전할 수 있도록 익명 데이터를 공유해주십시오</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">익명 데이터 공유</string>
   <!-- Enable touch ID prompt body -->
@@ -425,9 +425,9 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">잔액: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">\"설정\" &gt; \"앱\" &gt; \"Bread\" &gt; \"허용\"에서 카메라 접속을 허용해 주세요</string>
+  <string name="Send.cameraUnavailabeMessage.android">\"설정\" &gt; \"앱\" &gt; \"HODL\" &gt; \"허용\"에서 카메라 접속을 허용해 주세요</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread의 카메라 접속이 허용되지 않았습니다</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL의 카메라 접속이 허용되지 않았습니다</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">설정에서 카메라 액세스를 허가해 주세요.</string>
   <!-- Camera not allowed alert title -->
@@ -486,7 +486,7 @@
   <string name="Settings.currency">통화 보기</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">초기 버전을 사용해 보세요</string>
-  <!-- Are you enjoying bread alert message body -->
+  <!-- Are you enjoying HODL alert message body -->
   <string name="Settings.enjoying">브레드를 사용하고 있으신가요?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">지갑 내보내기</string>
@@ -562,7 +562,7 @@
   <string name="TouchIdSettings.spendingLimit">지불 한도: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
   <string name="TouchIdSettings.switchLabel">브레드에서</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">지문 본인확인 켜기</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">터치 ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">터치 센서</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Bread의 잠금을 해제하세요.</string>
+  <string name="UnlockScreen.touchIdPrompt">HODL의 잠금을 해제하세요.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">계속하시려면 귀하의 안드로이드 장치 잠금을 해제해 주세요.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">이 PIN 코드를 기억하세요. PIN 코드를 잊어버리면 자신의 비트코인을 사용할 수 없게 됩니다.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">귀하의 PIN 코드는 Bread의 잠금을 해제하고 돈을 송금하는 데 사용됩니다.</string>
+  <string name="UpdatePin.createInstruction">귀하의 PIN 코드는 HODL의 잠금을 해제하고 돈을 송금하는 데 사용됩니다.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">PIN 설정</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">이 거래 승인</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">귀하의 월렛을 설정하려면 Bread 앱을 열어 주세요.</string>
+  <string name="Watch.noWalletWarning">귀하의 월렛을 설정하려면 HODL 앱을 열어 주세요.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">무시</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,13 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">업데이트 중...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet이 이름을 Bread로 바꾸고 새롭게 단장하였으며 새로운 기능도 갖췄습니다.\n\n도움이 필요하시면 대부분 화면에서 우측 상단에 있는 (?)을(를) 클릭하십시오.</string>
+  <string name="Welcome.body">HODLwallet이 이름을 HODL로 바꾸고 새롭게 단장하였으며 새로운 기능도 갖췄습니다.\n\n도움이 필요하시면 대부분 화면에서 우측 상단에 있는 (?)을(를) 클릭하십시오.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Bread에 환영합니다!</string>
+  <string name="Welcome.title">HODL에 환영합니다!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title">HODL 지갑이 업그레이드되었습니다!</string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">정말 이 월렛을 삭제할까요?</string>
   <!-- Wipe wallet alert title -->
@@ -725,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">월렛을 초기화하고 다른 월렛을 시작하거나 복원하려면 이 월렛의 초기화 문구를 입력해 주세요. 현재 잔액은 이 문구에 그대로 보관됩니다.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">다른 지갑을 만들거나 복구하면 이 장치에서 다른 Bread 지갑을 이용하고 관리할 수 있습니다.</string>
+  <string name="WipeWallet.startMessage">다른 지갑을 만들거나 복구하면 이 장치에서 다른 HODL 지갑을 이용하고 관리할 수 있습니다.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">이장치에서 현재 Bread 지갑을 더는 이용할 수 없게 됩니다. 잔고는 남아 있게 됩니다.</string>
+  <string name="WipeWallet.startWarning">이장치에서 현재 HODL 지갑을 더는 이용할 수 없게 됩니다. 잔고는 남아 있게 됩니다.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">다른 월렛을 시작 또는 복원</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">다른 월렛을 시작/복원</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">레거시 주소 표시</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">레거시 주소</string>
   <!-- Share data view body -->
   <string name="ShareData.body">브레드 기능 향상을 위해 여러분의 익명 데이터를 공유해 주세요. 금융 정보는 포함되지 않습니다. 여러분의 금융 관련 개인정보는 안전하게 보호됩니다.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">지갑</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">다른 월렛을 시작/복원</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">레거시 주소 표시</string>
   <!-- Share data view body -->
   <string name="ShareData.body">브레드 기능 향상을 위해 여러분의 익명 데이터를 공유해 주세요. 금융 정보는 포함되지 않습니다. 여러분의 금융 관련 개인정보는 안전하게 보호됩니다.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -511,7 +511,9 @@
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Begin of herstel een andere portomonnee</string>
   <!-- Show Legacy Address. -->
-  <string name="Settings.legacyAddress">Toon Legacy adres</string>
+  <string name="Settings.legacyAddress">Toon Oud adres</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Oud adres</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Help om Bread te verbeteren door je anonieme data met ons te delen. Dit bevat geen financiële informatie. We respecteren je financiële privacy.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Portemonnee</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Begin of herstel een andere portomonnee</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Toon Legacy adres</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Help om Bread te verbeteren door je anonieme data met ons te delen. Dit bevat geen financiële informatie. We respecteren je financiële privacy.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blog</string>
   <!-- About screen footer -->
-  <string name="About.footer">Gemaakt door het globale Bread team. Versie %1$s</string>
+  <string name="About.footer">Gemaakt door het globale HODL team. Versie %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Privacyverklaring</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Portemonnee Laden</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Mijn Bread</string>
+  <string name="AccountHeader.defaultWalletName">Mijn HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Error</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Er is een probleem het uw Android OS keystore, neemt u alstublieft contact op met support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Er is een probleem het uw Android OS keystore, neemt u alstublieft contact op met support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Uw door Bread geëncrypteerde data is onlangs ongeldig gemaakt omdat uw Android schermvergrendeling is uitgeschakeld.</string>
+  <string name="Alert.keystore.invalidated.android">Uw door HODL geëncrypteerde data is onlangs ongeldig gemaakt omdat uw Android schermvergrendeling is uitgeschakeld.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Android KeyStore fout</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Portemonnee die geïmporteerd kan worden</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">Door een portemonnee te importeren plaats je het geld van je andere portemonnee naar je Bread portemonnee via een enkele transactie.</string>
+  <string name="Import.message">Door een portemonnee te importeren plaats je het geld van je andere portemonnee naar je HODL portemonnee via een enkele transactie.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Deze persoonlijke sleutel is beveiligd met een wachtwoord.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">wachtwoord</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Jouw Bread Portemonnee</string>
+  <string name="Import.rightCaption">Jouw HODL Portemonnee</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Scan Persoonlijke Sleutel</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Negeren</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">APPARAAT BEVEILIGING BESCHADIGD\nElke \'jailbreak\' app heeft toegang tot de sleutelhanger data van Bread en kan hiermee je Bitcoins stelen! Wis deze portemonnee direct en herstel het op een veilig apparaat.</string>
+  <string name="JailbreakWarnings.messageWithBalance">APPARAAT BEVEILIGING BESCHADIGD\nElke \'jailbreak\' app heeft toegang tot de sleutelhanger data van HODL en kan hiermee je Bitcoins stelen! Wis deze portemonnee direct en herstel het op een veilig apparaat.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">APPARAAT BEVEILIGING BESCHADIGD\nElke \'jailbreak\' app heeft toegang tot de sleutelhanger data van Bread en kan hiermee je Bitcoins stelen. Gebruik Bread a.u.b. alleen op een niet-gejailbreakt apparaat.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">APPARAAT BEVEILIGING BESCHADIGD\nElke \'jailbreak\' app heeft toegang tot de sleutelhanger data van HODL en kan hiermee je Bitcoins stelen. Gebruik HODL a.u.b. alleen op een niet-gejailbreakt apparaat.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">WAARSCHUWING</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Locatievoorzieningen zijn uitgeschakeld.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread heeft geen toestemming om locatievoorzieningen te gebruiken.</string>
+  <string name="LocationPlugin.notAuthorized">HODL heeft geen toestemming om locatievoorzieningen te gebruiken.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Je hebt je portemonnee gecreëerd op %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transactie Geweigerd</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Help ons bij het verbeteren van Bread door je anonieme data met ons te delen</string>
+  <string name="Prompts.ShareData.body">Help ons bij het verbeteren van HODL door je anonieme data met ons te delen</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Deel Anonieme Data</string>
   <!-- Enable touch ID prompt body -->
@@ -317,7 +317,7 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread is geüpgrade naar een 6-cijferige PIN. Tik hier om te upgraden.</string>
+  <string name="Prompts.UpgradePin.body">HODL is geüpgrade naar een 6-cijferige PIN. Tik hier om te upgraden.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">PIN Upgraden</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Papieren Sleutel Invoeren</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Herstel je Bread met je papieren sleutel.</string>
+  <string name="RecoverWallet.intro">Herstel je HODL met je papieren sleutel.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">De papieren sleutel die je hebt ingevoerd is ongeldig. Check ieder woord a.u.b. en probeer het opnieuw.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minuten</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Als een transactie als voltooid staat op het Bitcoin netwerk maar niet in je Bread.</string>
+  <string name="ReScan.body2">Als een transactie als voltooid staat op het Bitcoin netwerk maar niet in je HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Je kreeg herhaaldelijk een foutmelding die zei dat je transactie werd afgewezen.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Papieren Sleutel</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Beschermt je Bread van ongeautoriseerde gebruikers.</string>
+  <string name="SecurityCenter.pinDescription">Beschermt je HODL van ongeautoriseerde gebruikers.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6-cijferige PIN</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Veiligheidscentrum</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Ontgrendel je Bread handig en stuur geld tot een bepaalde ingestelde limiet.</string>
+  <string name="SecurityCenter.touchIdDescription">Ontgrendel je HODL handig en stuur geld tot een bepaalde ingestelde limiet.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Balans: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Sta cameratoegang toe via \"Instellingen\" &gt; \"Apps\" &gt; \"Bread\" &gt; \"Toestemmingen\"</string>
+  <string name="Send.cameraUnavailabeMessage.android">Sta cameratoegang toe via \"Instellingen\" &gt; \"Apps\" &gt; \"HODL\" &gt; \"Toestemmingen\"</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread heeft geen toegang tot de camera</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL heeft geen toegang tot de camera</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Ga naar Instellingen om camera gebruik toe te staan.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread heeft geen toestemming voor het gebruik van de camera</string>
+  <string name="Send.cameraUnavailableTitle">HODL heeft geen toestemming voor het gebruik van de camera</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">De bestemming is je eigen adres. Je kunt het niet naar jezelf sturen.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Toon valuta</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Doe Mee aan Early Access</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Vind je Bread leuk?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Vind je HODL leuk?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importeer Portemonnee</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">Oud adres</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Help om Bread te verbeteren door je anonieme data met ons te delen. Dit bevat geen financiële informatie. We respecteren je financiële privacy.</string>
+  <string name="ShareData.body">Help om HODL te verbeteren door je anonieme data met ons te delen. Dit bevat geen financiële informatie. We respecteren je financiële privacy.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Data Delen?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Schrijf Papieren Sleutel Opnieuw Op</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Je papieren sleutel is de enige manier om je Bread te herstellen als je telefoon verloren, gestolen, kapot of geüpgrade is.\n\nWe zullen je een lijst met woorden laten zie die je op een papiertje moet schrijven en veilig moet bewaren.</string>
+  <string name="StartPaperPhrase.body">Je papieren sleutel is de enige manier om je HODL te herstellen als je telefoon verloren, gestolen, kapot of geüpgrade is.\n\nWe zullen je een lijst met woorden laten zie die je op een papiertje moet schrijven en veilig moet bewaren.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Schrijf Papieren Sleutel Op</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Authenticatie met vingerafdruk niet ingesteld</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Gebruik je vingerafdruk om je Bread te ontgrendelen en geld tot een ingestelde limiet te versturen.</string>
+  <string name="TouchIdSettings.label">Gebruik je vingerafdruk om je HODL te ontgrendelen en geld tot een ingestelde limiet te versturen.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Touch-ID uitgavenlimietscherm</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Bestedingslimiet: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Schakel Touch ID in voor Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Schakel Touch ID in voor HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Stel authenticatie met vingerafdruk</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Aanraaksensor</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Ontgrendel je Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Ontgrendel je HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Ontgrendel alstublieft uw Android-apparaat om door te gaan.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Onthoud deze PIN. Als je deze vergeet, zul je niet in staat zijn om bij je Bitcoins te kunnen.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Je PIN zal worden gebruikt om je Bread te ontgrendelen en geld te versturen.</string>
+  <string name="UpdatePin.createInstruction">Je PIN zal worden gebruikt om je HODL te ontgrendelen en geld te versturen.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">PIN Instellen</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Autoriseer deze transactie</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Open de Bread iPhone app om je portemonnee in te stellen.</string>
+  <string name="Watch.noWalletWarning">Open de HODL iPhone app om je portemonnee in te stellen.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Verwerpen</string>
   <!-- Webview loading error message -->
@@ -711,7 +711,7 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Updaten...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet is omgedoopt tot Bread, met een gloednieuw uiterlijk en enkele nieuwe functies.\n\nAls u hulp nodig hebt, zoek naar de (?) rechtsboven in de meeste schermen.</string>
+  <string name="Welcome.body">HODLwallet is omgedoopt tot HODL, met een gloednieuw uiterlijk en enkele nieuwe functies.\n\nAls u hulp nodig hebt, zoek naar de (?) rechtsboven in de meeste schermen.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Welkom bij Brood!</string>
   <!-- Wipe wallet alert message -->
@@ -725,9 +725,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Voer de herstelzin van deze portomonnee in om hem te wissen of een anderen te herstellen. Je huidige saldo zal op deze zin blijven.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Een andere portemonnee beginnen of herstellen zal u toestaan om nog een Bread portemonnee op dit apparaat te gebruiken.</string>
+  <string name="WipeWallet.startMessage">Een andere portemonnee beginnen of herstellen zal u toestaan om nog een HODL portemonnee op dit apparaat te gebruiken.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">U zal niet langer uw huidige Bread portemonnee kunnen bereiken vanaf dit apparaat. Uw saldo zal hetzelfde blijven.</string>
+  <string name="WipeWallet.startWarning">U zal niet langer uw huidige HODL portemonnee kunnen bereiken vanaf dit apparaat. Uw saldo zal hetzelfde blijven.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Start of herstel een anderen portomonnee</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">Iniciar/recuperar outra carteira</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">Mostrar o legado endereço</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Endereço Herdado</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Ajude a melhorar a Bread partilhando os seus dados anónimos connosco. Isto não inclui quaisquer informações financeiras. Respeitamos a sua privacidade financeira.</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">As Breadwallets mudaram de nome para Bread, com um visual completamente novo e algumas características novas. \n\nSe precisar de ajuda, procure o (?) no canto superior direito da maioria das telas.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Bem-vindo ao Bread!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Tem a certeza de que quer eliminar esta carteira?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Carteira</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Iniciar/recuperar outra carteira</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Mostrar o legado endereço</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Ajude a melhorar a Bread partilhando os seus dados anónimos connosco. Isto não inclui quaisquer informações financeiras. Respeitamos a sua privacidade financeira.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blog</string>
   <!-- About screen footer -->
-  <string name="About.footer">Criada pela equipa Bread global. Versão %1$s</string>
+  <string name="About.footer">Criada pela equipa HODL global. Versão %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Política de Privacidade</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">A Carregar Carteira</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Minha Bread</string>
+  <string name="AccountHeader.defaultWalletName">Minha HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Erro</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Há um problema com a KeyStore do seu SO Android. Por favor, contacte support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Há um problema com a KeyStore do seu SO Android. Por favor, contacte support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Os seus dados encriptados pelo Bread foram recentemente invalidados porque o seu ecrã de bloqueio do Android estava desativado.</string>
+  <string name="Alert.keystore.invalidated.android">Os seus dados encriptados pelo HODL foram recentemente invalidados porque o seu ecrã de bloqueio do Android estava desativado.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Erro na KeyStore do Android</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Carteira a ser importada</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">Importar uma carteira transfere todo o dinheiro da sua outra carteira para a carteira Bread usando uma única transação.</string>
+  <string name="Import.message">Importar uma carteira transfere todo o dinheiro da sua outra carteira para a carteira HODL usando uma única transação.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Esta chave privada está protegida com uma palavra-passe.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">palavra-passe</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">A Sua Carteira Bread</string>
+  <string name="Import.rightCaption">A Sua Carteira HODL</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Digitalizar Chave Privada</string>
   <!-- Import wallet success alert title -->
@@ -217,7 +217,7 @@
   <!-- Jailbreak warning message -->
   <string name="JailbreakWarnings.messageWithBalance">SEGURANÇA DO DISPOSITIVO COMPROMETIDA\n Qualquer aplicação com \"jailbreak\" consegue aceder aos seus dados de porta-chaves e roubar as suas bitcoins! Apague esta carteira imediatamente e restaure-a num dispositivo seguro.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">SEGURANÇA DO DISPOSITIVO COMPROMETIDA\n Qualquer aplicação com \"jailbreak\" consegue aceder aos seus dados de porta-chaves da Bread e roubar as suas bitcoins. Por favor, use a Bread somente num dispositivo não desbloqueado.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">SEGURANÇA DO DISPOSITIVO COMPROMETIDA\n Qualquer aplicação com \"jailbreak\" consegue aceder aos seus dados de porta-chaves da HODL e roubar as suas bitcoins. Por favor, use a HODL somente num dispositivo não desbloqueado.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">AVISO</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Os serviços de localização estão desativados.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">A Bread não tem permissão para aceder aos serviços de localização.</string>
+  <string name="LocationPlugin.notAuthorized">A HODL não tem permissão para aceder aos serviços de localização.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Criou a sua carteira em %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transação Rejeitada</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Ajude a melhorar a Bread, partilhando connosco os seus dados anónimos</string>
+  <string name="Prompts.ShareData.body">Ajude a melhorar a HODL, partilhando connosco os seus dados anónimos</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Partilhar dados anónimos</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">A Bread foi atualizada para usar um PIN de 6-dígitos. Toque aqui para atualizar.</string>
+  <string name="Prompts.UpgradePin.body">A HODL foi atualizada para usar um PIN de 6-dígitos. Toque aqui para atualizar.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Atualizar PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Ative as notificações para receber mensagens especiais da Bread no futuro.</string>
+  <string name="PushNotifications.body">Ative as notificações para receber mensagens especiais da HODL no futuro.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Notificações Push</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Introduzir Chave de Papel</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Recupere a sua Bread com a sua chave de papel.</string>
+  <string name="RecoverWallet.intro">Recupere a sua HODL com a sua chave de papel.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">A chave de papel que introduziu é inválida. Por favor verifique cada palavra e tente novamente.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minutos</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Se uma transação aparece como concluída na sua rede bitcoin mas não na sua Bread.</string>
+  <string name="ReScan.body2">Se uma transação aparece como concluída na sua rede bitcoin mas não na sua HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Recebe repetidamente uma mensagem de erro dizendo que a sua transação foi rejeitada.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Chave de Papel</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Protege a sua Bread de utilizadores não autorizados.</string>
+  <string name="SecurityCenter.pinDescription">Protege a sua HODL de utilizadores não autorizados.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">PIN de 6-Dígitos</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Centro de Segurança</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Desbloqueie convenientemente a sua Bread e envie dinheiro até um limite definido</string>
+  <string name="SecurityCenter.touchIdDescription">Desbloqueie convenientemente a sua HODL e envie dinheiro até um limite definido</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Saldo: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Permita o acesso à câmara em \"Definições\" &gt; \"Aplicações\" &gt; \"Bread\" &gt; \"Permissões\"</string>
+  <string name="Send.cameraUnavailabeMessage.android">Permita o acesso à câmara em \"Definições\" &gt; \"Aplicações\" &gt; \"HODL\" &gt; \"Permissões\"</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">O Bread não tem autorização para aceder à câmara</string>
+  <string name="Send.cameraUnavailabeTitle.android">O HODL não tem autorização para aceder à câmara</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Vá às Definições para permitir acesso à câmara.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">A Bread não tem autorização para aceder à câmara</string>
+  <string name="Send.cameraUnavailableTitle">A HODL não tem autorização para aceder à câmara</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">O destino é o seu próprio endereço. Não pode enviar a si mesmo.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Mostrar moeda</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Registe-se no Acesso Antecipado</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Está a gostar da Bread?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Está a gostar da HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importar Carteira</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">Endereço Herdado</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Ajude a melhorar a Bread partilhando os seus dados anónimos connosco. Isto não inclui quaisquer informações financeiras. Respeitamos a sua privacidade financeira.</string>
+  <string name="ShareData.body">Ajude a melhorar a HODL partilhando os seus dados anónimos connosco. Isto não inclui quaisquer informações financeiras. Respeitamos a sua privacidade financeira.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Partilhar Dados?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Escrever Novamente Chave de Papel</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">A chave de papel é a única forma de restaurar a sua Bread se o seu telefone for perdido, roubado, partido ou atualizado.\n\nVamos mostrar-lhe uma lista de palavras para escrever numa folha de papel e manter em segurança.</string>
+  <string name="StartPaperPhrase.body">A chave de papel é a única forma de restaurar a sua HODL se o seu telefone for perdido, roubado, partido ou atualizado.\n\nVamos mostrar-lhe uma lista de palavras para escrever numa folha de papel e manter em segurança.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Escrever Chave de Papel</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Autenticação por Impressão Digital não Ativada</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Utilize a impressão digital para desbloquear a sua Bread e enviar dinheiro até um limite definido.</string>
+  <string name="TouchIdSettings.label">Utilize a impressão digital para desbloquear a sua HODL e enviar dinheiro até um limite definido.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Ecrã de limite dos gastos do Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Limite de Gastos: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Ativar Touch ID para a Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Ativar Touch ID para a HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Ativar a Autenticação por Impressão Digital</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Sensor de Toque</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Desbloqueie a sua Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Desbloqueie a sua HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Desbloqueie o seu dispositivo Android para continuar.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Lembre-se deste PIN. Se o esquecer, não será capaz de aceder às suas bitcoins.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">O seu PIN será usado para desbloquear a sua Bread e para enviar dinheiro.</string>
+  <string name="UpdatePin.createInstruction">O seu PIN será usado para desbloquear a sua HODL e para enviar dinheiro.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Definir PIN</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Autorizar esta transação</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Abra a aplicação Bread para iPhone para configurar a sua carteira.</string>
+  <string name="Watch.noWalletWarning">Abra a aplicação HODL para iPhone para configurar a sua carteira.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Ignorar</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,9 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">A Atualizar...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">As Breadwallets mudaram de nome para Bread, com um visual completamente novo e algumas características novas. \n\nSe precisar de ajuda, procure o (?) no canto superior direito da maioria das telas.</string>
+  <string name="Welcome.body">As HODLwallets mudaram de nome para HODL, com um visual completamente novo e algumas características novas. \n\nSe precisar de ajuda, procure o (?) no canto superior direito da maioria das telas.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Bem-vindo ao Bread!</string>
+  <string name="Welcome.title">Bem-vindo ao HODL!</string>
   <!-- Top title of segwit popup -->
   <string name="Segwit.title"></string>
   <!-- Message of segwit popup -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Introduza a frase de recuperação desta carteira, a fim de limpar a mesma e iniciar ou recuperar outra. O seu saldo atual permanece nesta frase.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Começar ou recuperar outra carteira permite-lhe entrar e administrar uma carteira diferente da Bread neste dispositivo.</string>
+  <string name="WipeWallet.startMessage">Começar ou recuperar outra carteira permite-lhe entrar e administrar uma carteira diferente da HODL neste dispositivo.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Não poderá mais aceder à sua Breadwallet a partir deste dispositivo. O saldo permanecerá na frase.</string>
+  <string name="WipeWallet.startWarning">Não poderá mais aceder à sua HODLwallet a partir deste dispositivo. O saldo permanecerá na frase.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Iniciar ou recuperar outra carteira</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">Запустить / восстановить другой кошелек</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">показать прежний адрес</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">прежний адрес</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Помогите нам улучшить Bread, поделившись своими анонимными данными. Такие данные не включают какую-либо финансовую информацию. Мы уважаем вашу финансовую конфиденциальность.</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwallet сменил свое название на Bread и обзавелся новым дизайном и функциями.\n\nЕсли вам нужна помощь, то ищите иконку (?) в правом верхнем углу большинства экранов.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Добро пожаловать в Bread!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Вы действительно хотите удалить этот кошелек?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Кошелек</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Запустить / восстановить другой кошелек</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">показать прежний адрес</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Помогите нам улучшить Bread, поделившись своими анонимными данными. Такие данные не включают какую-либо финансовую информацию. Мы уважаем вашу финансовую конфиденциальность.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Блог</string>
   <!-- About screen footer -->
-  <string name="About.footer">Создано международной командой Bread. Версия %1$s</string>
+  <string name="About.footer">Создано международной командой HODL. Версия %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Политика конфиденциальности</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Загружаем кошелек</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Мой Bread</string>
+  <string name="AccountHeader.defaultWalletName">Мой HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Ошибка</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Имеется проблема с хранилищем ключей в вашей ОС Android, обратитесь по адресу: support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Имеется проблема с хранилищем ключей в вашей ОС Android, обратитесь по адресу: support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Ваши зашифрованные данные приложения Bread были недавно аннулированы, так как была отключена блокировка экрана вашего устройства Android.</string>
+  <string name="Alert.keystore.invalidated.android">Ваши зашифрованные данные приложения HODL были недавно аннулированы, так как была отключена блокировка экрана вашего устройства Android.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Ошибка хранилища ключей Android</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Кошелек, который будет импортирован</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">При импортировании кошелька все ваши деньги из другого кошелька будут перенесены в ваш кошелек Bread с помощью одной транзакции.</string>
+  <string name="Import.message">При импортировании кошелька все ваши деньги из другого кошелька будут перенесены в ваш кошелек HODL с помощью одной транзакции.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Этот персональный ключ защищен паролем.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">пароль</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Ваш кошелек Bread</string>
+  <string name="Import.rightCaption">Ваш кошелек HODL</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Сканировать персональный ключ</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Игнорировать</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">БЕЗОПАСНОСТЬ УСТРОЙСТВА ПОДВЕРГНУТА РИСКУ\n Какое-либо приложение по снятию ограничений с файловой системы может получить доступ к данным цепочки ключей  Bread и украсть ваши биткойны! Немедленно очистите ваш кошелек и восстановите его на безопасном устройстве.</string>
+  <string name="JailbreakWarnings.messageWithBalance">БЕЗОПАСНОСТЬ УСТРОЙСТВА ПОДВЕРГНУТА РИСКУ\n Какое-либо приложение по снятию ограничений с файловой системы может получить доступ к данным цепочки ключей  HODL и украсть ваши биткойны! Немедленно очистите ваш кошелек и восстановите его на безопасном устройстве.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">БЕЗОПАСНОСТЬ УСТРОЙСТВА ПОДВЕРГНУТА РИСКУ\n Какое-либо приложение по снятию ограничений с файловой системы может получить доступ к данным цепочки ключей  Bread и украсть ваши биткойны. Пожалуйста, используйте Bread только на устройствах с не снятыми с файловой системы ограничениями.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">БЕЗОПАСНОСТЬ УСТРОЙСТВА ПОДВЕРГНУТА РИСКУ\n Какое-либо приложение по снятию ограничений с файловой системы может получить доступ к данным цепочки ключей  HODL и украсть ваши биткойны. Пожалуйста, используйте HODL только на устройствах с не снятыми с файловой системы ограничениями.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">ПРЕДУПРЕЖДЕНИЕ</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Сервисы определения местоположения отключены.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">У Bread не разрешения на доступ к сервисам определения местоположения.</string>
+  <string name="LocationPlugin.notAuthorized">У HODL не разрешения на доступ к сервисам определения местоположения.</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Вы создали ваш кошелек %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Транзакция отклонена</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Помогите улучшить Bread, поделившись с нами своими анонимными данными</string>
+  <string name="Prompts.ShareData.body">Помогите улучшить HODL, поделившись с нами своими анонимными данными</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Поделиться анонимными данными</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN-код</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread обновил свой интерфейс до использования 6-цифрового PIN-кода. Коснитесь здесь для обновления.</string>
+  <string name="Prompts.UpgradePin.body">HODL обновил свой интерфейс до использования 6-цифрового PIN-кода. Коснитесь здесь для обновления.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Обновить PIN-код</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Включите уведомления, чтобы в будущем получать от Bread важные сообщения.</string>
+  <string name="PushNotifications.body">Включите уведомления, чтобы в будущем получать от HODL важные сообщения.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Push-уведомления</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Введите бумажный ключ</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Восстановите Ваш Bread-кошелек с помощью бумажного ключа.</string>
+  <string name="RecoverWallet.intro">Восстановите Ваш HODL-кошелек с помощью бумажного ключа.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">Введенный вами бумажный ключ недействителен. Пожалуйста, внимательно перепроверьте каждое слово и повторите попытку.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 минут</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Если транзакция описывается как \"выполненная\" в биткойн-сети, но не в вашем Bread-кошельке.</string>
+  <string name="ReScan.body2">Если транзакция описывается как \"выполненная\" в биткойн-сети, но не в вашем HODL-кошельке.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Вы несколько раз получили ошибку о том, что транзакция отвергнута.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Бумажный ключ</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Защищает ваш Bread от несанкционированных пользователей.</string>
+  <string name="SecurityCenter.pinDescription">Защищает ваш HODL от несанкционированных пользователей.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6-цифровой PIN-код</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Центр безопасности</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Легко и просто разблокируйте ваш Bread-кошелек и отправляйте суммы, не превышающие ваш лимит на расходы.</string>
+  <string name="SecurityCenter.touchIdDescription">Легко и просто разблокируйте ваш HODL-кошелек и отправляйте суммы, не превышающие ваш лимит на расходы.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Баланс: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Разрешить доступ к камере в: \"Настройки\" &gt; \"Приложения\" &gt; \"Bread\" &gt; \"Разрешения\"</string>
+  <string name="Send.cameraUnavailabeMessage.android">Разрешить доступ к камере в: \"Настройки\" &gt; \"Приложения\" &gt; \"HODL\" &gt; \"Разрешения\"</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Приложению Bread не разрешен доступ к камере</string>
+  <string name="Send.cameraUnavailabeTitle.android">Приложению HODL не разрешен доступ к камере</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Перейдите в \"Настройки\", чтобы разрешить доступ к камере.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread не имеет разрешения на доступ к камере</string>
+  <string name="Send.cameraUnavailableTitle">HODL не имеет разрешения на доступ к камере</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">Место назначения является вашим собственным адресом. Вы не можете отправить деньги самому себе.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Отображать валюту</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Присоединитесь к пользователям с ранним доступом</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Нравится ли вам использовать Bread?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Нравится ли вам использовать HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Импортировать кошелек</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">прежний адрес</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Помогите нам улучшить Bread, поделившись своими анонимными данными. Такие данные не включают какую-либо финансовую информацию. Мы уважаем вашу финансовую конфиденциальность.</string>
+  <string name="ShareData.body">Помогите нам улучшить HODL, поделившись своими анонимными данными. Такие данные не включают какую-либо финансовую информацию. Мы уважаем вашу финансовую конфиденциальность.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Поделиться данными?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Выписать бумажный ключ снова</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Бумажный ключ – это единственный способ восстановить ваш Bread-кошелек в случае потери, кражи, поломки или замены вашего телефона.\n\nМы покажем вам список слов, которые необходимо записать на листе бумаги и хранить в надежном месте.</string>
+  <string name="StartPaperPhrase.body">Бумажный ключ – это единственный способ восстановить ваш HODL-кошелек в случае потери, кражи, поломки или замены вашего телефона.\n\nМы покажем вам список слов, которые необходимо записать на листе бумаги и хранить в надежном месте.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Выписать бумажный ключ</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Аутентификация по отпечаткам пальцев не включена</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Используйте отпечатки ваших пальцев для разблокирования Bread-кошелька и отправки сумм, не превышающих ваш лимит на расходы.</string>
+  <string name="TouchIdSettings.label">Используйте отпечатки ваших пальцев для разблокирования HODL-кошелька и отправки сумм, не превышающих ваш лимит на расходы.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Экран лимита расходов Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Лимит на расходы: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Активировать функцию Touch ID для Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Активировать функцию Touch ID для HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Включить аутентификацию по отпечаткам пальцев</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Датчик касания</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Разблокируйте ваш Bread-кошелек.</string>
+  <string name="UnlockScreen.touchIdPrompt">Разблокируйте ваш HODL-кошелек.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Разблокируйте ваше устройство Android, чтобы продолжить.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Запомните этот PIN-код. Если вы его забудете, что не сможете получить доступ к вашим биткойнам.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Ваш PIN-код будет использоваться для разблокировки кошелька Bread и отправки денег.</string>
+  <string name="UpdatePin.createInstruction">Ваш PIN-код будет использоваться для разблокировки кошелька HODL и отправки денег.</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Задайте PIN-код</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Разрешить эту транзакцию</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Запустите Bread-приложение для iPhone, чтобы настроить ваш кошелек.</string>
+  <string name="Watch.noWalletWarning">Запустите HODL-приложение для iPhone, чтобы настроить ваш кошелек.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Отклонить</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,9 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Идет обновление...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet сменил свое название на Bread и обзавелся новым дизайном и функциями.\n\nЕсли вам нужна помощь, то ищите иконку (?) в правом верхнем углу большинства экранов.</string>
+  <string name="Welcome.body">HODLwallet сменил свое название на HODL и обзавелся новым дизайном и функциями.\n\nЕсли вам нужна помощь, то ищите иконку (?) в правом верхнем углу большинства экранов.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Добро пожаловать в Bread!</string>
+  <string name="Welcome.title">Добро пожаловать в HODL!</string>
   <!-- Top title of segwit popup -->
   <string name="Segwit.title"></string>
   <!-- Message of segwit popup -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Введите фразу восстановления кошелька для того, чтобы его удалить и запустить или восстановить другой. Ваш текущий баланс остается на этой фразе.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Создание или восстановление другого кошелька позволит вам получить доступ или управлять другим кошельком Bread на этом устройстве.</string>
+  <string name="WipeWallet.startMessage">Создание или восстановление другого кошелька позволит вам получить доступ или управлять другим кошельком HODL на этом устройстве.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Вы больше не сможете получить доступ к текущему кошельку Bread с этого устройства. Ваш баланс останется на этой фразе.</string>
+  <string name="WipeWallet.startWarning">Вы больше не сможете получить доступ к текущему кошельку HODL с этого устройства. Ваш баланс останется на этой фразе.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Запуск или восстановление другого кошелька</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">Plånbok</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Starta/Återställ en annan plånbok</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">Visa Legacy adress</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Hjälp till att förbättra Bread genom att dela dina anonyma uppgifter med oss. Detta inbegriper inga ekonomiska uppgifter. Vi respekterar din ekonomiska sekretess.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">Blogg</string>
   <!-- About screen footer -->
-  <string name="About.footer">Skapad av det lokala teamet för Bread. Version %1$s</string>
+  <string name="About.footer">Skapad av det lokala teamet för HODL. Version %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">Sekretesspolicy</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">Laddar plånbok</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">Mitt Bread</string>
+  <string name="AccountHeader.defaultWalletName">Mitt HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">Fel</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">Det har uppstått ett problem med KeyStore till Android OS. Kontakta support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">Det har uppstått ett problem med KeyStore till Android OS. Kontakta support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">Dina krypterade Bread-uppgifter har nyligen ogiltigförklarats på grund av att Androids skärmlås inaktiverades.</string>
+  <string name="Alert.keystore.invalidated.android">Dina krypterade HODL-uppgifter har nyligen ogiltigförklarats på grund av att Androids skärmlås inaktiverades.</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">KeyStore-fel för Android</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">Plånbok som ska importeras</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">Genom att importera en plånbok överförs alla pengar från din andra plånbok till Bread genom en enda transaktion.</string>
+  <string name="Import.message">Genom att importera en plånbok överförs alla pengar från din andra plånbok till HODL genom en enda transaktion.</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">Denna privata nyckel är lösenordsskyddad.</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">lösenord</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">Din Bread-plånbok</string>
+  <string name="Import.rightCaption">Din HODL-plånbok</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">Läs av privat nyckel</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">Ignorera</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">ENHETENS SÄKERHET ÄR ÄVENTYRAD\nEn \"intrångs\"-app kan få tillgång till Breads nyckeldata och stjäla dina bitcoin! Töm denna plånbok direkt och återupprätta den på en säker enhet.</string>
+  <string name="JailbreakWarnings.messageWithBalance">ENHETENS SÄKERHET ÄR ÄVENTYRAD\nEn \"intrångs\"-app kan få tillgång till HODLs nyckeldata och stjäla dina bitcoin! Töm denna plånbok direkt och återupprätta den på en säker enhet.</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">ENHETENS SÄKERHET ÄR ÄVENTYRAD\nEn \"intrångs\"-app kan få tillgång till Breads nyckeldata och stjäla dina bitcoin! Använd Bread endast på en säker enhet.</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">ENHETENS SÄKERHET ÄR ÄVENTYRAD\nEn \"intrångs\"-app kan få tillgång till HODLs nyckeldata och stjäla dina bitcoin! Använd HODL endast på en säker enhet.</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">VARNING</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">Platstjänster är inaktiverade.</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread har inte rätt att utnyttja platstjänster</string>
+  <string name="LocationPlugin.notAuthorized">HODL har inte rätt att utnyttja platstjänster</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">Du skapade din plånbok på %1$s</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">Transaktionen avslogs</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">Hjälp till att förbättra Bread genom att dela dina anonyma data med oss</string>
+  <string name="Prompts.ShareData.body">Hjälp till att förbättra HODL genom att dela dina anonyma data med oss</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">Dela anonyma data</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">PIN-kod</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread har uppgraderat till att använda 6-siffrig PIN-kod. Klicka här för att uppgradera.</string>
+  <string name="Prompts.UpgradePin.body">HODL har uppgraderat till att använda 6-siffrig PIN-kod. Klicka här för att uppgradera.</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">Uppgradera PIN-kod</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">Slå på aviseringar för att få särskilda meddelanden från Bread i framtiden.</string>
+  <string name="PushNotifications.body">Slå på aviseringar för att få särskilda meddelanden från HODL i framtiden.</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">Push-meddelanden</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">Ange ordnyckel</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">Återupprätta Bread med din ordnyckel.</string>
+  <string name="RecoverWallet.intro">Återupprätta HODL med din ordnyckel.</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">Den ordnyckel du angav är ogiltig. Dubbelkolla varje ord och försök igen.</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 minuter</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">Om en transaktion visar sig som klar i bitcoins nätverk men inte i Bread.</string>
+  <string name="ReScan.body2">Om en transaktion visar sig som klar i bitcoins nätverk men inte i HODL.</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">Du får gång på gång ett meddelande som säger att din transaktion avvisades.</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">Ordnyckel</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">Skyddar ditt Bread från obehöriga användare.</string>
+  <string name="SecurityCenter.pinDescription">Skyddar ditt HODL från obehöriga användare.</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6-siffrig PIN-kod</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">Säkerhetscenter</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">Lås enkelt upp ditt Bread och skicka pengar upp till en inställd gräns.</string>
+  <string name="SecurityCenter.touchIdDescription">Lås enkelt upp ditt HODL och skicka pengar upp till en inställd gräns.</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">Saldo: %1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">Tillåt kameraåtkomst under Inställningar &gt; Appar &gt; Bread &gt; Behörigheter</string>
+  <string name="Send.cameraUnavailabeMessage.android">Tillåt kameraåtkomst under Inställningar &gt; Appar &gt; HODL &gt; Behörigheter</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread har inte åtkomst till kameran</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL har inte åtkomst till kameran</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">Gå till Inställningar för att ge tillgång till kameran.</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread har inte tillgång till kameran</string>
+  <string name="Send.cameraUnavailableTitle">HODL har inte tillgång till kameran</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">Destinationen är din egen adress. Du kan inte skicka till dig själv.</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">Visa valuta</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">Använd Snabb tillgång</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">Gillar du Bread?</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">Gillar du HODL?</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">Importera plånbok</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">äldre adress</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">Hjälp till att förbättra Bread genom att dela dina anonyma uppgifter med oss. Detta inbegriper inga ekonomiska uppgifter. Vi respekterar din ekonomiska sekretess.</string>
+  <string name="ShareData.body">Hjälp till att förbättra HODL genom att dela dina anonyma uppgifter med oss. Detta inbegriper inga ekonomiska uppgifter. Vi respekterar din ekonomiska sekretess.</string>
   <!-- Share data header -->
   <string name="ShareData.header">Dela uppgifter?</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">Skriv ner ordnyckel på nytt</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">Din ordnyckel  är enda sättet att återupprätta Bread om du förlorat din telefon, blivit bestulen på den eller har uppgraderat den.\n\nVi visar dig en lista över ord som du kan skriva ner på ett papper och gömma undan.</string>
+  <string name="StartPaperPhrase.body">Din ordnyckel  är enda sättet att återupprätta HODL om du förlorat din telefon, blivit bestulen på den eller har uppgraderat den.\n\nVi visar dig en lista över ord som du kan skriva ner på ett papper och gömma undan.</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">Skriv ner ordnyckel</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">Fingeravtrycksautentisering har inte aktiverats</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">Använd ditt fingeravtryck för att låsa upp Bread och skicka pengar upp till en inställd gräns.</string>
+  <string name="TouchIdSettings.label">Använd ditt fingeravtryck för att låsa upp HODL och skicka pengar upp till en inställd gräns.</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Sida för utgiftsgräns i Touch ID</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">Utnyttjandegräns: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">Aktivera Touch ID för Bread</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">Aktivera Touch ID för HODL</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Aktivera fingeravtrycksautentisering</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">Touchsensor</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">Lås upp Bread.</string>
+  <string name="UnlockScreen.touchIdPrompt">Lås upp HODL.</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">Lås upp din Android-enhet för att fortsätta.</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">Kom ihåg PIN-koden. Om du glömmer den, kommer du inte åt dina bitcoin.</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">Din PIN-kod används för att låsa upp ditt Bread och skicka pengar</string>
+  <string name="UpdatePin.createInstruction">Din PIN-kod används för att låsa upp ditt HODL och skicka pengar</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">Ställ in PIN-kod</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">Godkänn denna transaktion</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">Öppna iPhone-appen Bread för att ställa in din plånbok.</string>
+  <string name="Watch.noWalletWarning">Öppna iPhone-appen HODL för att ställa in din plånbok.</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">Avfärda</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,9 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Uppdaterar...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadplånboken har bytt namn till Bread, med ett splitter nytt utseende och några nya funktioner.\n\nOm du behöver hjälp, leta efter (?)-tecknet i det övre högra hörnet på de flesta skärmar.</string>
+  <string name="Welcome.body">HODLplånboken har bytt namn till HODL, med ett splitter nytt utseende och några nya funktioner.\n\nOm du behöver hjälp, leta efter (?)-tecknet i det övre högra hörnet på de flesta skärmar.</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">Välkommen till Bread!</string>
+  <string name="Welcome.title">Välkommen till HODL!</string>
   <!-- Top title of segwit popup -->
   <string name="Segwit.title"></string>
   <!-- Message of segwit popup -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">Ange den här plånbokens återställningsfras för att rensa den och starta eller återställa en annan. Ditt nuvarande saldo är kvar på den här frasen.</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">Att starta eller återställa en annan plånbok ger dig tillgång till och låter dig hantera en annan Breadplånbok på denna enhet.</string>
+  <string name="WipeWallet.startMessage">Att starta eller återställa en annan plånbok ger dig tillgång till och låter dig hantera en annan HODLplånbok på denna enhet.</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">Du kommer inte längre att kunna komma åt din aktuella Breadplånbok från denna enhet. Saldot kommer att kvarstå på frasen.</string>
+  <string name="WipeWallet.startWarning">Du kommer inte längre att kunna komma åt din aktuella HODLplånbok från denna enhet. Saldot kommer att kvarstå på frasen.</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">Starta eller hämta en annan plånbok</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">Starta/Återställ en annan plånbok</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">Visa Legacy adress</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">äldre adress</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Hjälp till att förbättra Bread genom att dela dina anonyma uppgifter med oss. Detta inbegriper inga ekonomiska uppgifter. Vi respekterar din ekonomiska sekretess.</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadplånboken har bytt namn till Bread, med ett splitter nytt utseende och några nya funktioner.\n\nOm du behöver hjälp, leta efter (?)-tecknet i det övre högra hörnet på de flesta skärmar.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Välkommen till Bread!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Är du säker på att du vill ta bort den här plånboken.</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">博客</string>
   <!-- About screen footer -->
-  <string name="About.footer">由全球 Bread 团队制作。版本%1$s</string>
+  <string name="About.footer">由全球 HODL 团队制作。版本%1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">隐私政策</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">正在加载钱包</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">我的 Bread</string>
+  <string name="AccountHeader.defaultWalletName">我的 HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">错误</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">您的安卓操作系统密钥库存在问题，请联系support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">您的安卓操作系统密钥库存在问题，请联系support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">您的 Bread 加密数据最近因为您的安卓系统屏幕锁定被禁用而失效。</string>
+  <string name="Alert.keystore.invalidated.android">您的 HODL 加密数据最近因为您的安卓系统屏幕锁定被禁用而失效。</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">安卓系统密钥库错误</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">待导入钱包</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">导入钱包，利用单笔交易将您其他钱包里的所有钱转移到您的 Bread  钱包。</string>
+  <string name="Import.message">导入钱包，利用单笔交易将您其他钱包里的所有钱转移到您的 HODL  钱包。</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">本私钥受到密码保护。</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">密码</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">您的 Bread 钱包</string>
+  <string name="Import.rightCaption">您的 HODL 钱包</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">扫描私钥</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">忽略</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">设备安全性受损\n任何\'越狱\'应用都可能访问 Bread 的密钥链数据并盗取您的比特币！立即擦除这个钱包并在一台安全设备上进行恢复。</string>
+  <string name="JailbreakWarnings.messageWithBalance">设备安全性受损\n任何\'越狱\'应用都可能访问 HODL 的密钥链数据并盗取您的比特币！立即擦除这个钱包并在一台安全设备上进行恢复。</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">设备安全性受损\n任何\'越狱\'应用都可能访问 Bread 的密钥链数据并盗取您的比特币！请您仅在未越狱设备上使用 Bread 。</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">设备安全性受损\n任何\'越狱\'应用都可能访问 HODL 的密钥链数据并盗取您的比特币！请您仅在未越狱设备上使用 HODL 。</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">警告</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">位置服务被禁用。</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread 无权限访问位置服务。</string>
+  <string name="LocationPlugin.notAuthorized">HODL 无权限访问位置服务。</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">您在%1$s上创建了您的钱包</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">交易被拒</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">与我们分享您的匿名数据来帮助改善 Bread。</string>
+  <string name="Prompts.ShareData.body">与我们分享您的匿名数据来帮助改善 HODL。</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">分享匿名数据</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">密码</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread 已升级到使用 6 位 PIN。点击此处升级。</string>
+  <string name="Prompts.UpgradePin.body">HODL 已升级到使用 6 位 PIN。点击此处升级。</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">升级 PIN</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">打开推送通知，以便将来从 Bread 接收特殊消息。</string>
+  <string name="PushNotifications.body">打开推送通知，以便将来从 HODL 接收特殊消息。</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">推送通知</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">输入纸键</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">用您的纸键恢复您的 Bread。</string>
+  <string name="RecoverWallet.intro">用您的纸键恢复您的 HODL。</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">您输入的纸键无效。请仔细检查每个单词并重试。</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 分钟</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">如果某次交易在比特币网络上显示为已完成，却不在您的 Bread 里。</string>
+  <string name="ReScan.body2">如果某次交易在比特币网络上显示为已完成，却不在您的 HODL 里。</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">你反复得到交易被拒绝的出错信息。</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">纸键</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">保护您的 Bread 免遭未授权用户盗用。</string>
+  <string name="SecurityCenter.pinDescription">保护您的 HODL 免遭未授权用户盗用。</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6 位 PIN</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">安全中心</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">方便地解锁 Bread，在设定限额下汇钱。</string>
+  <string name="SecurityCenter.touchIdDescription">方便地解锁 HODL，在设定限额下汇钱。</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">触摸 ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">余额：%1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">在“设置”&gt;“应用”&gt;“Bread”&gt;“权限”中允许访问相机</string>
+  <string name="Send.cameraUnavailabeMessage.android">在“设置”&gt;“应用”&gt;“HODL”&gt;“权限”中允许访问相机</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread 没有访问相机的权限</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL 没有访问相机的权限</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">前往“设置”以允许访问照相机。</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread 不允许访问照相机</string>
+  <string name="Send.cameraUnavailableTitle">HODL 不允许访问照相机</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">目标是您自己的地址。您不能发送给您自己。</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">显示币种</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">加入早期访问</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">您喜欢 Bread 吗？</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">您喜欢 HODL 吗？</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">导入钱包</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">遗产地址</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">同我们分享您的匿名数据来帮助改善 Bread。这不包括任何财务信息。我们尊重您的财务隐私。</string>
+  <string name="ShareData.body">同我们分享您的匿名数据来帮助改善 HODL。这不包括任何财务信息。我们尊重您的财务隐私。</string>
   <!-- Share data header -->
   <string name="ShareData.header">共享数据？</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">再次书写纸键</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">如果您的手机丢失、被盗、损坏或升级，纸上密钥是恢复 Bread 的唯一方法。\n\n\n我们将向您显示一张单词表，请将其写在纸上并保存在安全的地方。</string>
+  <string name="StartPaperPhrase.body">如果您的手机丢失、被盗、损坏或升级，纸上密钥是恢复 HODL 的唯一方法。\n\n\n我们将向您显示一张单词表，请将其写在纸上并保存在安全的地方。</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">写下纸键</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">指纹认证未启用</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">请用指纹解锁 Bread 并在设定限额下汇钱。</string>
+  <string name="TouchIdSettings.label">请用指纹解锁 HODL 并在设定限额下汇钱。</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Touch ID 支出限额屏幕</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">支出限制：%1$s (%2$s)</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">针对 Bread 启用触摸 ID</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">针对 HODL 启用触摸 ID</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">指纹认证</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">触摸 ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">触控感应器</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">解锁您的 Bread。</string>
+  <string name="UnlockScreen.touchIdPrompt">解锁您的 HODL。</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">请解锁您的安卓设备以便继续。</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">请牢记此 PIN 码。如果您忘记，您将无法访问您的比特币。</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">您的 PIN 码将用于解锁您的 Bread 并发送款项。</string>
+  <string name="UpdatePin.createInstruction">您的 PIN 码将用于解锁您的 HODL 并发送款项。</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">设置 PIN 码</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">授权此交易</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">打开 Bread iPhone app 以设置您的钱包。</string>
+  <string name="Watch.noWalletWarning">打开 HODL iPhone app 以设置您的钱包。</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">忽略</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,9 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">正在更新...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet 更名为 Bread， 并增加了全新的界面和功能。如果您需要帮助，请使用在大多数设备屏幕右上角的(?)</string>
+  <string name="Welcome.body">HODLwallet 更名为 HODL， 并增加了全新的界面和功能。如果您需要帮助，请使用在大多数设备屏幕右上角的(?)</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">欢迎使用bread！</string>
+  <string name="Welcome.title">欢迎使用HODL！</string>
   <!-- Top title of segwit popup -->
   <string name="Segwit.title"></string>
   <!-- Message of segwit popup -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">输入此钱包的恢复短语以擦除并启动或恢复另一钱包。您的当前余额将保留。</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">开始或恢复另一个钱包能让你在这个设备上管理和使用不同的bread钱包</string>
+  <string name="WipeWallet.startMessage">开始或恢复另一个钱包能让你在这个设备上管理和使用不同的HODL钱包</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">您无法再在这个设备上使用现在的Bread钱包。 现在的一切资金都留在纸键上。</string>
+  <string name="WipeWallet.startWarning">您无法再在这个设备上使用现在的HODL钱包。 现在的一切资金都留在纸键上。</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">启动或恢复另一钱包</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">钱包</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">开始/恢复另一钱包</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">显示旧地址</string>
   <!-- Share data view body -->
   <string name="ShareData.body">同我们分享您的匿名数据来帮助改善 Bread。这不包括任何财务信息。我们尊重您的财务隐私。</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">开始/恢复另一钱包</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">显示旧地址</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">遗产地址</string>
   <!-- Share data view body -->
   <string name="ShareData.body">同我们分享您的匿名数据来帮助改善 Bread。这不包括任何财务信息。我们尊重您的财务隐私。</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwallet 更名为 Bread， 并增加了全新的界面和功能。如果您需要帮助，请使用在大多数设备屏幕右上角的(?)</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">欢迎使用bread！</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">您确认要删除此钱包吗？</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -510,6 +510,8 @@
   <string name="Settings.wallet">錢包</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">開啟／復原其他錢包</string>
+  <!-- Show Legacy Address. -->
+  <string name="Settings.legacyAddress">顯示舊位址</string>
   <!-- Share data view body -->
   <string name="ShareData.body">請跟我們分享您的匿名資料，以協助我們改善 Bread。其中不會包含財務資訊。我們尊重您的財務隱私。</string>
   <!-- Share data header -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -512,6 +512,8 @@
   <string name="Settings.wipe">開啟／復原其他錢包</string>
   <!-- Show Legacy Address. -->
   <string name="Settings.legacyAddress">顯示舊位址</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">遺產地址</string>
   <!-- Share data view body -->
   <string name="ShareData.body">請跟我們分享您的匿名資料，以協助我們改善 Bread。其中不會包含財務資訊。我們尊重您的財務隱私。</string>
   <!-- Share data header -->
@@ -712,6 +714,10 @@
   <string name="Welcome.body">Breadwallet 已經改名爲 Bread，有嶄新的面貌和一些新功能。\n\n如果需要協助，就在大部分畫面的右上角尋找(?)。</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">歡迎使用 Bread！</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title"></string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message"></string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">確定要刪除此錢包嗎？</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- App name -->
-  <string name="About.appName.android">Bread</string>
+  <string name="About.appName.android">HODL</string>
   <!-- About screen blog label -->
   <string name="About.blog">部落格</string>
   <!-- About screen footer -->
-  <string name="About.footer">由全球 Bread 團隊製作。版本 %1$s</string>
+  <string name="About.footer">由全球 HODL 團隊製作。版本 %1$s</string>
   <!-- Privay Policy button label -->
   <string name="About.privacy">隱私政策</string>
   <!-- About screen reddit label -->
@@ -23,7 +23,7 @@
   <!-- Loading Wallet Message -->
   <string name="Account.loadingMessage">正在載入電子錢包</string>
   <!-- Default wallet name -->
-  <string name="AccountHeader.defaultWalletName">我的 Bread</string>
+  <string name="AccountHeader.defaultWalletName">我的 HODL</string>
   <!-- Equals symbol -->
   <string name="AccountHeader.equals">=</string>
   <!-- Manage wallet button title -->
@@ -33,9 +33,9 @@
   <!-- Error alert title -->
   <string name="Alert.error">錯誤</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">您的 Android OS 金鑰儲存區有問題，請聯絡 support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">您的 Android OS 金鑰儲存區有問題，請聯絡 support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
-  <string name="Alert.keystore.invalidated.android">您的 Bread 加密資料最近已被判定為無效，因爲您的 Android 螢幕鎖定已被停用。</string>
+  <string name="Alert.keystore.invalidated.android">您的 HODL 加密資料最近已被判定為無效，因爲您的 Android 螢幕鎖定已被停用。</string>
   <!-- Keystore error title -->
   <string name="Alert.keystore.title.android">Android 金鑰儲存區錯誤</string>
   <!-- No internet alert message -->
@@ -189,13 +189,13 @@
   <!-- Caption for graphics -->
   <string name="Import.leftCaption">待匯入的電子錢包</string>
   <!-- Import wallet intro screen message -->
-  <string name="Import.message">匯入一個電子錢包會以單一交易的方式將您其它電子錢包的所有資金轉帳至您的 Bread 錢包。</string>
+  <string name="Import.message">匯入一個電子錢包會以單一交易的方式將您其它電子錢包的所有資金轉帳至您的 HODL 錢包。</string>
   <!-- Enter password alert view title -->
   <string name="Import.password">此私密金鑰受密碼保護。</string>
   <!-- password textfield placeholder -->
   <string name="Import.passwordPlaceholder">密碼</string>
   <!-- Caption for graphics -->
-  <string name="Import.rightCaption">您的 Bread 錢包</string>
+  <string name="Import.rightCaption">您的 HODL 錢包</string>
   <!-- Scan Private key button label -->
   <string name="Import.scan">掃描私密金鑰</string>
   <!-- Import wallet success alert title -->
@@ -215,9 +215,9 @@
   <!-- Ignore jailbreak warning button -->
   <string name="JailbreakWarnings.ignore">略過</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithBalance">裝置安全性遭破解\n 任何「越獄」應用程式都可以存取 Bread 的鑰匙圈資料、 竊取您的比特幣！立即抹除這個錢包，在安全的裝置上還原。</string>
+  <string name="JailbreakWarnings.messageWithBalance">裝置安全性遭破解\n 任何「越獄」應用程式都可以存取 HODL 的鑰匙圈資料、 竊取您的比特幣！立即抹除這個錢包，在安全的裝置上還原。</string>
   <!-- Jailbreak warning message -->
-  <string name="JailbreakWarnings.messageWithoutBalance">裝置安全性遭破解\n 任何「越獄」應用程式都可以存取 Bread 的鑰匙圈資料、 竊取您的比特幣。請只在未越獄的裝置上使用 Bread。</string>
+  <string name="JailbreakWarnings.messageWithoutBalance">裝置安全性遭破解\n 任何「越獄」應用程式都可以存取 HODL 的鑰匙圈資料、 竊取您的比特幣。請只在未越獄的裝置上使用 HODL。</string>
   <!-- Jailbreak warning title -->
   <string name="JailbreakWarnings.title">警告</string>
   <!-- Wipe wallet button -->
@@ -225,7 +225,7 @@
   <!-- Location services disabled error -->
   <string name="LocationPlugin.disabled">定位服務已停用。</string>
   <!-- No permissions for location services -->
-  <string name="LocationPlugin.notAuthorized">Bread 沒有存取定位服務的權限。</string>
+  <string name="LocationPlugin.notAuthorized">HODL 沒有存取定位服務的權限。</string>
   <!-- Wallet creation date prefix -->
   <string name="ManageWallet.creationDatePrefix">您在 %1$s 建立了電子錢包</string>
   <!-- Manage wallet description text -->
@@ -303,7 +303,7 @@
   <!-- Transaction rejected prompt title -->
   <string name="Prompts.RecommendRescan.title">交易被拒</string>
   <!-- Share data prompt body -->
-  <string name="Prompts.ShareData.body">和我們分享您的匿名資料來協助改善 Bread</string>
+  <string name="Prompts.ShareData.body">和我們分享您的匿名資料來協助改善 HODL</string>
   <!-- Share data prompt title -->
   <string name="Prompts.ShareData.title">分享匿名資料</string>
   <!-- Enable touch ID prompt body -->
@@ -317,11 +317,11 @@
   <!-- Button on fingerprint prompt so the user can enter their PIN instead -->
   <string name="Prompts.TouchId.usePin.android">密碼</string>
   <!-- Upgrade PIN prompt body. -->
-  <string name="Prompts.UpgradePin.body">Bread 已經升級至 6 位數 PIN 碼。請點這裡升級。</string>
+  <string name="Prompts.UpgradePin.body">HODL 已經升級至 6 位數 PIN 碼。請點這裡升級。</string>
   <!-- Upgrade PIN prompt title. -->
   <string name="Prompts.UpgradePin.title">升級 PIN 碼</string>
   <!-- Notifications will be added later but users can set their preferences now, which is why we specify "in the future". -->
-  <string name="PushNotifications.body">開啟通知，好在未來收到 Bread 的特別訊息。</string>
+  <string name="PushNotifications.body">開啟通知，好在未來收到 HODL 的特別訊息。</string>
   <!-- Push notifications toggle switch label -->
   <string name="PushNotifications.label">推播</string>
   <!-- Push notifications are off label -->
@@ -351,7 +351,7 @@
   <!-- Enter paper key instruction -->
   <string name="RecoverWallet.instruction">輸入紙本金鑰</string>
   <!-- Recover wallet intro -->
-  <string name="RecoverWallet.intro">以您的紙本金鑰復原您的 Bread</string>
+  <string name="RecoverWallet.intro">以您的紙本金鑰復原您的 HODL</string>
   <!-- Invalid paper key message -->
   <string name="RecoverWallet.invalid">紙本金鑰</string>
   <!-- Previous button accessibility label -->
@@ -379,7 +379,7 @@
   <!-- extimated time -->
   <string name="ReScan.body1">20-45 分鐘</string>
   <!-- Syncing explanation -->
-  <string name="ReScan.body2">如果交易在比特幣網上已經顯示為完成，但沒有出現在您的 Bread 上。</string>
+  <string name="ReScan.body2">如果交易在比特幣網上已經顯示為完成，但沒有出現在您的 HODL 上。</string>
   <!-- Syncing explanation -->
   <string name="ReScan.body3">你不斷收到「交易被拒」的錯誤。</string>
   <!-- Start Sync button label -->
@@ -409,13 +409,13 @@
   <!-- Paper Key button title -->
   <string name="SecurityCenter.paperKeyTitle">紙本金鑰</string>
   <!-- PIN button description -->
-  <string name="SecurityCenter.pinDescription">保護您的 Bread，防範未經授權的使用者。</string>
+  <string name="SecurityCenter.pinDescription">保護您的 HODL，防範未經授權的使用者。</string>
   <!-- PIN button title -->
   <string name="SecurityCenter.pinTitle">6 位數 PIN 碼</string>
   <!-- Security Center Title -->
   <string name="SecurityCenter.title">資訊安全中心</string>
   <!-- Touch ID button description -->
-  <string name="SecurityCenter.touchIdDescription">輕鬆解鎖您的 Bread，並在設定好的限額內寄送款項。</string>
+  <string name="SecurityCenter.touchIdDescription">輕鬆解鎖您的 HODL，並在設定好的限額內寄送款項。</string>
   <!-- Touch ID button title -->
   <string name="SecurityCenter.touchIdTitle">Touch ID</string>
   <!-- Security center fingerprint authentication button -->
@@ -425,13 +425,13 @@
   <!-- Balance: $4.00 -->
   <string name="Send.balance">餘額：%1$s</string>
   <!-- Instructions how to allow the camera access for the app -->
-  <string name="Send.cameraUnavailabeMessage.android">到「設定」 &gt; 「應用程式」 &gt; 「Bread」 &gt; 「權限」允許相機存取</string>
+  <string name="Send.cameraUnavailabeMessage.android">到「設定」 &gt; 「應用程式」 &gt; 「HODL」 &gt; 「權限」允許相機存取</string>
   <!-- Permission required to access camera -->
-  <string name="Send.cameraUnavailabeTitle.android">Bread 尚未獲准存取相機</string>
+  <string name="Send.cameraUnavailabeTitle.android">HODL 尚未獲准存取相機</string>
   <!-- Camera not allowed message -->
   <string name="Send.cameraunavailableMessage">請至「設定」允許存取相機。</string>
   <!-- Camera not allowed alert title -->
-  <string name="Send.cameraUnavailableTitle">Bread 未獲得存取相機的權限</string>
+  <string name="Send.cameraUnavailableTitle">HODL 未獲得存取相機的權限</string>
   <!-- Warning when sending to self. -->
   <string name="Send.containsAddress">目的地為您自己的地址。您不能寄送給自己。</string>
   <!-- Could not create transaction alert title -->
@@ -486,8 +486,8 @@
   <string name="Settings.currency">顯示貨幣</string>
   <!-- Join Early access label -->
   <string name="Settings.earlyAccess">參加「先行體驗」</string>
-  <!-- Are you enjoying bread alert message body -->
-  <string name="Settings.enjoying">您喜歡 Bread 嗎？</string>
+  <!-- Are you enjoying HODL alert message body -->
+  <string name="Settings.enjoying">您喜歡 HODL 嗎？</string>
   <!-- Import wallet label -->
   <string name="Settings.importTitle">匯入電子錢包</string>
   <!-- Manage settings section header -->
@@ -515,7 +515,7 @@
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddressTitle">遺產地址</string>
   <!-- Share data view body -->
-  <string name="ShareData.body">請跟我們分享您的匿名資料，以協助我們改善 Bread。其中不會包含財務資訊。我們尊重您的財務隱私。</string>
+  <string name="ShareData.body">請跟我們分享您的匿名資料，以協助我們改善 HODL。其中不會包含財務資訊。我們尊重您的財務隱私。</string>
   <!-- Share data header -->
   <string name="ShareData.header">分享資料？</string>
   <!-- Share data switch label. -->
@@ -523,7 +523,7 @@
   <!-- button label -->
   <string name="StartPaperPhrase.againButtonTitle">再寫一次紙本金鑰</string>
   <!-- Paper key explanation text. -->
-  <string name="StartPaperPhrase.body">您的手機遺失、損壞或升級時，紙本金鑰是復原\n Bread 唯一的方式。\n\n我們會向您出示一個字串，請寫在紙上並妥善保管。</string>
+  <string name="StartPaperPhrase.body">您的手機遺失、損壞或升級時，紙本金鑰是復原\n HODL 唯一的方式。\n\n我們會向您出示一個字串，請寫在紙上並妥善保管。</string>
   <!-- button label -->
   <string name="StartPaperPhrase.buttonTitle">寫下紙本金鑰</string>
   <!-- Argument is date -->
@@ -555,14 +555,14 @@
   <!-- Fingerprint Is Not Setup -->
   <string name="TouchIdSettings.disabledWarning.title.android">指紋驗證並未啟用</string>
   <!-- Touch Id screen label -->
-  <string name="TouchIdSettings.label">以您的指紋解鎖 Bread，並在設定好的限額內寄送款項。</string>
+  <string name="TouchIdSettings.label">以您的指紋解鎖 HODL，並在設定好的限額內寄送款項。</string>
   <!-- Link Text (see TouchIdSettings.customizeText) -->
   <string name="TouchIdSettings.linkText">Touch ID 支出限額畫面</string>
   <!-- Spending Limit: b100,000 ($100) -->
   <string name="TouchIdSettings.spendingLimit">花費上限：%1$s（%2$s）</string>
   <!-- Touch id switch label. -->
-  <string name="TouchIdSettings.switchLabel">為 Bread 啟用 Touch ID</string>
-  <!-- Enable fingerprint for this wallet called Bread -->
+  <string name="TouchIdSettings.switchLabel">為 HODL 啟用 Touch ID</string>
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">指紋驗證</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -657,7 +657,7 @@
   <!-- Instruction to touch the sensor for fingerprint authentication -->
   <string name="UnlockScreen.touchIdInstructions.android">觸控感測器</string>
   <!-- TouchID prompt text -->
-  <string name="UnlockScreen.touchIdPrompt">解鎖您的 Bread。</string>
+  <string name="UnlockScreen.touchIdPrompt">解鎖您的 HODL。</string>
   <!-- Device authentication body -->
   <string name="UnlockScreen.touchIdPrompt.android">請解除鎖定您的 Android 裝置來繼續。</string>
   <!-- Unlock with TouchID accessibility label -->
@@ -669,7 +669,7 @@
   <!-- Update PIN caption text -->
   <string name="UpdatePin.caption">請記住此 PIN 碼。如果忘記，會無法存取您的比特幣。</string>
   <!-- PIN creation info. -->
-  <string name="UpdatePin.createInstruction">您的 PIN 碼會用於解鎖 Bread 及送出款項。</string>
+  <string name="UpdatePin.createInstruction">您的 PIN 碼會用於解鎖 HODL 及送出款項。</string>
   <!-- Update PIN title -->
   <string name="UpdatePin.createTitle">設定 PIN 碼</string>
   <!-- Update PIN title -->
@@ -703,7 +703,7 @@
   <!-- Authorize transaction with touch id message -->
   <string name="VerifyPin.touchIdMessage">授權此交易</string>
   <!-- 'No wallet' warning for watch app -->
-  <string name="Watch.noWalletWarning">開啟 Bread iPhone 應用程式以設定您的錢包。</string>
+  <string name="Watch.noWalletWarning">開啟 HODL iPhone 應用程式以設定您的錢包。</string>
   <!-- Dismiss button label -->
   <string name="Webview.dismiss">駁回</string>
   <!-- Webview loading error message -->
@@ -711,9 +711,9 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">正在更新……</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet 已經改名爲 Bread，有嶄新的面貌和一些新功能。\n\n如果需要協助，就在大部分畫面的右上角尋找(?)。</string>
+  <string name="Welcome.body">HODLwallet 已經改名爲 HODL，有嶄新的面貌和一些新功能。\n\n如果需要協助，就在大部分畫面的右上角尋找(?)。</string>
   <!-- Top title of welcome screen -->
-  <string name="Welcome.title">歡迎使用 Bread！</string>
+  <string name="Welcome.title">歡迎使用 HODL！</string>
   <!-- Top title of segwit popup -->
   <string name="Segwit.title"></string>
   <!-- Message of segwit popup -->
@@ -729,9 +729,9 @@
   <!-- Enter phrase to wipe wallet instruction. -->
   <string name="WipeWallet.instruction">輸入此錢包的復原短語（recovery phrase）以進行抹除，並開啟或復原其他錢包。您目前的餘額會保留在於短語。</string>
   <!-- Start wipe wallet view message -->
-  <string name="WipeWallet.startMessage">開始或復原另一個電子錢包會讓您能夠在這項裝置上存取和管理不一樣的 Bread 錢包。</string>
+  <string name="WipeWallet.startMessage">開始或復原另一個電子錢包會讓您能夠在這項裝置上存取和管理不一樣的 HODL 錢包。</string>
   <!-- Start wipe wallet view warning -->
-  <string name="WipeWallet.startWarning">您將再也無法從這項裝置存取目前的 Bread 錢包。餘額會留在片段上。</string>
+  <string name="WipeWallet.startWarning">您將再也無法從這項裝置存取目前的 HODL 錢包。餘額會留在片段上。</string>
   <!-- Wipe wallet navigation item title. -->
   <string name="WipeWallet.title">開啟或復原其他錢包</string>
   <!-- Wipe wallet button title -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -739,9 +739,9 @@
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Welcome to HODL Wallet!</string>
   <!-- Top title of segwit popup -->
-  <string name="Segwit.title">HODL Wallet has Segwit!</string>
+  <string name="Segwit.title">HODL Wallet has Upgraded!</string>
   <!-- Message of segwit popup -->
-  <string name="Segwit.message">Your HODL Wallet has been upgraded to Segwit using the standard address format Bech32.\nSince some services might require the old address format you can get a legacy address via Settings / Wallet / Show Legacy Address.</string>
+  <string name="Segwit.message">HODL Wallet has upgraded to the newest Bitcoin address standard. This gives you the added benefit of saving on transaction fees and being compatible with the latest standards of the Bitcoin Network. You don\'t have to do anything different and the only thing you\'ll notice is your addresses have changed and now begin with "btc".\n\nYour money is safe and still stored on your Backup Recovery Key.\n\nSince this change is still taking effect across the Bitcoin Network, some services may not be ready to send to this new address type. If you encounter this you can still access the old addresses that begin with \"1\" via: Settings/ Wallet/ Show Legacy Address</string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Are you sure you want to delete this wallet?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -528,6 +528,8 @@
   <string name="Settings.wipe">Start/Recover Another Wallet</string>
   <!-- Get a legacy address menu label. -->
   <string name="Settings.legacyAddress">Show Legacy Address</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddressTitle">Legacy Address</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Help improve HODL Wallet by sharing your anonymous data with us. This does not include any financial information. We respect your financial privacy.</string>
   <!-- Share data header -->
@@ -736,6 +738,10 @@
   <string name="Welcome.body">Breadwallet has changed its name to BRD, with a brand new look and some new features.\n\nIf you need help, look for the (?) in the top right of most screens.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Welcome to HODL Wallet!</string>
+  <!-- Top title of segwit popup -->
+  <string name="Segwit.title">HODL Wallet has Segwit!</string>
+  <!-- Message of segwit popup -->
+  <string name="Segwit.message">Your HODL Wallet has been upgraded to Segwit using the standard address format Bech32.\nSince some services might require the old address format you can get a legacy address via Settings / Wallet / Show Legacy Address.</string>
   <!-- Wipe wallet alert message -->
   <string name="WipeWallet.alertMessage">Are you sure you want to delete this wallet?</string>
   <!-- Wipe wallet alert title -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -526,6 +526,8 @@
   <string name="Settings.wallet">Wallet</string>
   <!-- Start or recover another wallet menu label. -->
   <string name="Settings.wipe">Start/Recover Another Wallet</string>
+  <!-- Get a legacy address menu label. -->
+  <string name="Settings.legacyAddress">Show Legacy Address</string>
   <!-- Share data view body -->
   <string name="ShareData.body">Help improve HODL Wallet by sharing your anonymous data with us. This does not include any financial information. We respect your financial privacy.</string>
   <!-- Share data header -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
   <!-- Error alert title -->
   <string name="Alert.error">Error</string>
   <!-- Keystore error -->
-  <string name="Alert.keystore.generic.android">There is a problem with your Android OS keystore, please contact support@breadwallet.com</string>
+  <string name="Alert.keystore.generic.android">There is a problem with your Android OS keystore, please contact support@hodlwallet.co</string>
   <!-- KeyStore error, keys are invalidated -->
   <string name="Alert.keystore.invalidated.android">Your wallet encrypted data was recently invalidated because your Android lock screen was disabled.</string>
   <!-- Keystore error title -->
@@ -578,7 +578,7 @@
   <string name="TouchIdSettings.spendingLimit">Spending limit: %1$s (%2$s)</string>
   <!-- Touch id switch label. -->
   <string name="TouchIdSettings.switchLabel">Enable Touch ID for HODL</string>
-  <!-- Enable fingerprint for this wallet called BRD -->
+  <!-- Enable fingerprint for this wallet called HODL -->
   <string name="TouchIdSettings.switchLabel.android">Enable Fingerprint Authentication</string>
   <!-- Touch ID settings view title -->
   <string name="TouchIdSettings.title">Touch ID</string>
@@ -735,7 +735,7 @@
   <!-- Updating webview message -->
   <string name="Webview.updating">Updating...</string>
   <!-- Welcome screen text. (?) will be replaced with the help icon users should look for. -->
-  <string name="Welcome.body">Breadwallet has changed its name to BRD, with a brand new look and some new features.\n\nIf you need help, look for the (?) in the top right of most screens.</string>
+  <string name="Welcome.body">HODLwallet has changed its name to HODL, with a brand new look and some new features.\n\nIf you need help, look for the (?) in the top right of most screens.</string>
   <!-- Top title of welcome screen -->
   <string name="Welcome.title">Welcome to HODL Wallet!</string>
   <!-- Top title of segwit popup -->


### PR DESCRIPTION
Adds `bech32` support to the wallet showing the older format on settings.

Please test, under `Menu -> Settings -> Wallet  Section -> Show Legacy Address`.

#### TODO

- [x] Translation of `Show Legacy Address`.
- [x] Change and translation of `Receive` to `Legacy Address`

#### Also on this PR

- [x] Update `secp256k1`
- [x] Update missing translations on all languages.